### PR TITLE
Add support for detecting Amazon Silk browser

### DIFF
--- a/assets/test/matchers.yml
+++ b/assets/test/matchers.yml
@@ -132,6 +132,8 @@ samsung-browser:
   ios: Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.20 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36
   linux: Mozilla/5.0 (SMART-TV; Linux; Tizen 2.3) AppleWebkit/538.1 (KHTML, like Gecko) SamsungBrowser/1.0 TV Safari/538.1
   windows: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.2 Chrome/51.0.2704.106 DEX Safari/537.36
+silk-browser:
+  android: Mozilla/5.0 (Linux; Android 9; KFMUWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.5.9 like Chrome/130.0.6723.142 Safari/537.36
 snapchat:
   android: Mozilla/5.0 (Linux; Android 7.1.1; Coolpad 3632A Build/NMF26F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/60.0.3112.116 Mobile Safari/537.36 Snapchat/10.18.2.0 (Coolpad 3632A; Android 7.1.1#108560743#25; gzip)
   ios: Snapchat 10.22.2.0 (iPhone10,6; iOS 11.1.2; gzip)

--- a/browser.go
+++ b/browser.go
@@ -92,6 +92,7 @@ func (b *Browser) register() {
 		matchers.NewEdge(parser),
 		matchers.NewInternetExplorer(parser),
 		matchers.NewSamsungBrowser(parser),
+		matchers.NewSilkBrowser(parser),
 		matchers.NewSogouBrowser(parser),
 		matchers.NewVivaldi(parser),
 		matchers.NewVivoBrowser(parser),
@@ -429,6 +430,17 @@ func (b *Browser) IsInternetExplorer() bool {
 // IsSamsungBrowser returns true if the browser is SamsungBrowser.
 func (b *Browser) IsSamsungBrowser() bool {
 	if _, ok := b.getMatcher().(*matchers.SamsungBrowser); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsSilkBrowser returns true if the browser is Amazon Silk browser.
+//
+// https://docs.aws.amazon.com/silk/
+func (b *Browser) IsSilkBrowser() bool {
+	if _, ok := b.getMatcher().(*matchers.SilkBrowser); ok {
 		return true
 	}
 

--- a/browser_test.go
+++ b/browser_test.go
@@ -784,6 +784,26 @@ func TestBrowserIsSamsungBrowser(t *testing.T) {
 	})
 }
 
+func TestBrowserIsSilkBrowser(t *testing.T) {
+	Convey("Subject: #IsSilkBrowser", t, func() {
+		Convey("When the browser is Silk Browser", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["silk-browser"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsSilkBrowser(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the browser is not Silk Browser", func() {
+			Convey("It should return false", func() {
+				ua := testUserAgents["chrome"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsSilkBrowser(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
 func TestBrowserIsSougouBrowser(t *testing.T) {
 	Convey("Subject: #IsSougouBrowser", t, func() {
 		Convey("When the browser is Sougou Browser", func() {

--- a/matchers/silk_browser.go
+++ b/matchers/silk_browser.go
@@ -1,0 +1,33 @@
+package matchers
+
+type SilkBrowser struct {
+	p Parser
+}
+
+var (
+	silkBrowserName         = "Silk"
+	silkBrowserVersionRegex = []string{
+		`(?i)Silk/([\d.]+)`,
+		`Chrome/([\d.]+)`,
+		`Safari/([\d.]+)`,
+	}
+	silkBrowserMatchRegex = []string{`Silk/`}
+)
+
+func NewSilkBrowser(p Parser) *SilkBrowser {
+	return &SilkBrowser{
+		p: p,
+	}
+}
+
+func (s *SilkBrowser) Name() string {
+	return silkBrowserName
+}
+
+func (s *SilkBrowser) Version() string {
+	return s.p.Version(silkBrowserVersionRegex, 1)
+}
+
+func (s *SilkBrowser) Match() bool {
+	return s.p.Match(silkBrowserMatchRegex)
+}

--- a/matchers/silk_browser_test.go
+++ b/matchers/silk_browser_test.go
@@ -1,0 +1,62 @@
+package matchers
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewSilkBrowser(t *testing.T) {
+	Convey("Subject: #NewSilkBrowser", t, func() {
+		Convey("It should return a new SilkBrowser instance", func() {
+			So(NewSilkBrowser(NewUAParser("")), ShouldHaveSameTypeAs, &SilkBrowser{})
+		})
+	})
+}
+
+func TestSilkBrowserName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Silk", func() {
+			sb := NewSilkBrowser(NewUAParser(""))
+			So(sb.Name(), ShouldEqual, "Silk")
+		})
+	})
+}
+
+func TestSilkBrowserVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It should return the version", func() {
+				sb := testUserAgents["silk-browser"]
+
+				So(NewSilkBrowser(NewUAParser(sb.Android)).Version(), ShouldEqual, "130.5.9")
+			})
+		})
+
+		Convey("When the version is not matched", func() {
+			Convey("It should return default version", func() {
+				sb := NewSilkBrowser(NewUAParser("Mozilla/5.0 (Linux; Android 4.4.2; SM-G900F Build/KOT49H)"))
+				So(sb.Version(), ShouldEqual, "0.0")
+			})
+		})
+	})
+}
+
+func TestSilkBrowserMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Silk Browser", func() {
+			Convey("It should return true", func() {
+				sb := testUserAgents["silk-browser"]
+
+				So(NewSilkBrowser(NewUAParser(sb.Android)).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Silk Browser", func() {
+			Convey("It should return false", func() {
+				sb := NewSilkBrowser(NewUAParser(testUserAgents["chrome"].Linux))
+				So(sb.Match(), ShouldBeFalse)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Introduced a new matcher for Amazon Silk browser including its name, version, and matching logic. Added corresponding tests, integrated the matcher into the browser detection flow, and updated test user agent data to include an example for Silk.