### PR TITLE
Add more targets

### DIFF
--- a/assets/internal/known_bots.yml
+++ b/assets/internal/known_bots.yml
@@ -21,7 +21,7 @@ archiveteam archivebot: ArchiveTeam ArchiveBot
 ask jeeves: Ask Jeeves
 asynchttpclient: Java http and WebSocket client library
 awe.sm: Awe.sm URL expander
-baidu: Baidu
+baiduspider: Baidu
 barkrowler: Barkrowler
 bdcbot: Big Data Corp
 becomebot: BecomeBot (become.com)

--- a/assets/test/devices.yml
+++ b/assets/test/devices.yml
@@ -36,6 +36,7 @@ ipad-2: Mozilla/5.0 (iPad; CPU OS 12_1_1 like Mac OS X) AppleWebKit/605.1.15 (KH
 ipad-3: Mozilla/5.0 (iPad; CPU OS 15_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Browlser/4.2
 ipad-4: Mozilla/5.0 (iPad; CPU OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) CriOS/29.0.1547.11 Mobile/9B206 Safari/7534.48.3
 ipad-5: bonprix mobile App 1.40 (20200325.1) (iOS 13.3; iPad) AppleWebKit (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25
+ipad-6: Mozilla/5.0 (iPad; CPU iPhone OS 18_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Version/18.1.1 Safari/605.1.15 AlohaBrowser/6.5.0
 iphone-1: Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en-us) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3 XiaoMi/MiuiBrowser/2.1.1
 iphone-2: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B93 Electron/like MathspaceIOS/2.7.2
 iphone-3: bonprix mobile App 1.36 (20191101.3) (iOS 13.2; iPhone) AppleWebKit (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25

--- a/assets/test/devices.yml
+++ b/assets/test/devices.yml
@@ -70,6 +70,7 @@ switch-2: Opera/9.30 (Nintendo Switch; U; ; 2047-7; de)
 switch-3: Nintendo Wii Browser(Nintendo Switch Lite)
 tv-1: Mozilla/5.0 (Linux; Android 5.1.1; Nexus Player Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
 tv-2: Mozilla/5.0 (Linux; Android 5.0.2; ADT-1 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.94 Mobile Safari/537.36
+tv-3: Mozilla/5.0 (Linux; NetCast; U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.3945.79 Safari/537.36 SmartTV/10.0 Colt/2.0
 wii-1: MSIE 999; Nintendo WIi; Mozilla/5.0; (Win64)
 wii-2: Mozilla/5.0 (Nintendo Wii; U; en-US) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4200.1 Safari/537.36
 wii-3: Google Chrome/10 (Nintendo Wii)

--- a/assets/test/matchers.yml
+++ b/assets/test/matchers.yml
@@ -86,6 +86,8 @@ miui-browser:
   ios: Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10 XiaoMi/Mi-Pad/MiuiBrowser/1.0
   linux: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.34 Safari/534.24 XiaoMi/MiuiBrowser/2.0.1
   windows: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/71.0.3578.141 Safari/534.24 XiaoMi/MiuiBrowser/12.5.2-gn
+nintendo:
+  linux: Mozilla/5.0 (Nintendo Switch; WifiWebAuthApplet) AppleWebKit/609.4 (KHTML, like Gecko) NF/6.0.2.26.0 NintendoBrowser/5.1.0.23653
 nokia:
   android: Mozilla/5.0 (Linux; Android 4.1.2; Nokia_X Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36 NokiaBrowser/1.2.0.12
   linux: Mozilla/5.0 (Series40; Nokia302/14.53; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/2.3.0.0.48

--- a/assets/test/matchers.yml
+++ b/assets/test/matchers.yml
@@ -132,6 +132,8 @@ samsung-browser:
   ios: Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.20 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36
   linux: Mozilla/5.0 (SMART-TV; Linux; Tizen 2.3) AppleWebkit/538.1 (KHTML, like Gecko) SamsungBrowser/1.0 TV Safari/538.1
   windows: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.2 Chrome/51.0.2704.106 DEX Safari/537.36
+silk-browser:
+  android: Mozilla/5.0 (Linux; Android 9; KFMUWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.5.9 like Chrome/130.0.6723.142 Safari/537.36
 snapchat:
   android: Mozilla/5.0 (Linux; Android 7.1.1; Coolpad 3632A Build/NMF26F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/60.0.3112.116 Mobile Safari/537.36 Snapchat/10.18.2.0 (Coolpad 3632A; Android 7.1.1#108560743#25; gzip)
   ios: Snapchat 10.22.2.0 (iPhone10,6; iOS 11.1.2; gzip)

--- a/assets/test/matchers.yml
+++ b/assets/test/matchers.yml
@@ -6,6 +6,9 @@ alipay:
   windows: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/538.1 (KHTML like Gecko) alipay_demo1 Safari/538.1
 android-browser:
   android: Mozilla/5.0     (Linux; U) AppleWebKit/537.36 (KHTML, like Gecko)     Version/4.0 Mobile Safari/537.36 SmartTV/7.0 (NetCast) Android
+baidu:
+  android: Mozilla/5.0 (Linux; Android 10; HLK-AL00 Build/HONORHLK-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/97.0.4692.98 Mobile Safari/537.36 T7/13.81 BDOS/1.0 (HarmonyOS 2.2.0) SP-engine/3.22.0 baiduboxapp/13.81.1.10 (Baidu; P1 10) NABar/1.0
+  ios: Mozilla/5.0 (iPhone; CPU iPhone OS 18_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 SP-engine/3.22.0 main/1.0 baiduboxapp/13.81.1.10 (Baidu; P2 18.1.1) NABar/1.0 themeUA=Theme/default
 blackberry:
   android: Mozilla/5.0 (Linux; Android 7.1.1; BBB100-3 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   ios: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 ZONApp/iOS/1.8.1 bb105a49-62d6-4895-b831-6c1da9c92e6e

--- a/assets/test/matchers.yml
+++ b/assets/test/matchers.yml
@@ -4,6 +4,8 @@ alipay:
   ios: Mozilla/5.0 (iPhone; CPU iPhone OS 9_3 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E230 ChannelId(3) Nebula PSDType(1) AlipayDefined(nt:WIFI,ws:320|504|2.0) AliApp(AP/9.9.0.000001) AlipayClient/9.9.0.000001 Language/zh-Hans ProductType/dev
   mac: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2,AlipayClient) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.134 Safari/537.36
   windows: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/538.1 (KHTML like Gecko) alipay_demo1 Safari/538.1
+android-browser:
+  android: Mozilla/5.0     (Linux; U) AppleWebKit/537.36 (KHTML, like Gecko)     Version/4.0 Mobile Safari/537.36 SmartTV/7.0 (NetCast) Android
 blackberry:
   android: Mozilla/5.0 (Linux; Android 7.1.1; BBB100-3 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   ios: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 ZONApp/iOS/1.8.1 bb105a49-62d6-4895-b831-6c1da9c92e6e

--- a/assets/test/matchers.yml
+++ b/assets/test/matchers.yml
@@ -20,6 +20,10 @@ chrome:
   linux: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36
   mac: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.155 Safari/537.36
   windows: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.155 Safari/537.36
+coc-coc:
+  android: Mozilla/5.0 (Linux; Android 9.0.99; MYNETTV-2H) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/80.0.232 Chrome/74.0.3729.232 Safari/537.36
+  mac: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/94.0.210 Chrome/88.0.4324.210 Safari/537.36
+  windows: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/56.3.162 Chrome/50.3.2661.162 Safari/537.36
 duck_duck_go:
   android: Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.132 Mobile Safari/537.36 DuckDuckGo/5
   ios: DuckDuckGo/2 CFNetwork/897.15 Darwin/17.5.0

--- a/assets/test/platforms.yml
+++ b/assets/test/platforms.yml
@@ -89,3 +89,4 @@ windows-rt: Mozilla/5.0 (Windows NT 6.3; ARM; Trident/7.0; Touch; .NET4.0E; .NET
 windows-touch: Mozilla/5.0 (Windows NT 6.3; ARM; Trident/7.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0; rv:11.0) like Gecko
 windows-vista: Mozilla/5.0 (Windows NT 6.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) mtz_krunker/1.15.10 Chrome/78.0.3905.1 Electron/7.0.0 Safari/537.36
 windows-xp: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; Wildfire NoTrail; ProE-Datecode:2902011330),gzip(gfe) (via translate.google.com)
+xbox: Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.64

--- a/assets/test/platforms.yml
+++ b/assets/test/platforms.yml
@@ -86,7 +86,8 @@ windows-8: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like G
 windows-8-1: Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Min/1.1.2 Chrome/49.0.2623.75 Electron/0.37.1 Safari/537.36
 windows-ce: Mozilla/5.0 (Windows CE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36
 windows-inclusive: Mozilla/5.0 (Windows NT 5.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) your-app/0.1.0 Chrome/41.0.2272.76 Electron/0.24.0 Safari/537.36
-windows-phone: Mozilla/5.0 (Windows Phone 10.0 like Android 6.0.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile/537.36 Version/12.10136
+windows-phone-1: Mozilla/5.0 (Windows Phone 10.0 like Android 6.0.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile/537.36 Version/12.10136
+windows-phone-2: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; Lumia 640 XL Dual SIM) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
 windows-rt: Mozilla/5.0 (Windows NT 6.3; ARM; Trident/7.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0; rv:11.0) like Gecko
 windows-touch: Mozilla/5.0 (Windows NT 6.3; ARM; Trident/7.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0; rv:11.0) like Gecko
 windows-vista: Mozilla/5.0 (Windows NT 6.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) mtz_krunker/1.15.10 Chrome/78.0.3905.1 Electron/7.0.0 Safari/537.36

--- a/assets/test/platforms.yml
+++ b/assets/test/platforms.yml
@@ -72,6 +72,7 @@ linux: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) At
 mac-os: XMind/10.2.1.202007271856 (darwin.x64; macOS Arch/x64 Version/11.0.1; en-US) Electron/5.0.13
 mac-os-1: MOZILLA/5.0 (MACINTOSH; INTEL MAC OS X 10_14_6) APPLEWEBKIT/537.36 (KHTML LIKE GECKO) CHROME/94.0.4606.61 SAFARI/537.36
 mac-os-x: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11) AppleWebKit/537.36 (KHTML, like Gecko) NativefierPlaceholder/0.0.1 Chrome/47.0.2526.73 Electron/0.36.4 Safari/537.36
+nintendo: Mozilla/5.0 (Nintendo Switch; WifiWebAuthApplet) AppleWebKit/609.4 (KHTML, like Gecko) NF/6.0.2.26.0 NintendoBrowser/5.1.0.23653
 playstation-3: Mozilla/5.0 (PLAYSTATION 3 4.91) AppleWebKit/531.22.8 (KHTML, like Gecko)
 playstation-4: Mozilla/5.0 (PlayStation; PlayStation 4/12.00) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15
 playstation-5: Mozilla/5.0 (PlayStation; PlayStation 5/10.40; PlayStation 4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15

--- a/assets/test/platforms.yml
+++ b/assets/test/platforms.yml
@@ -78,6 +78,8 @@ playstation-4: Mozilla/5.0 (PlayStation; PlayStation 4/12.00) AppleWebKit/605.1.
 playstation-5: Mozilla/5.0 (PlayStation; PlayStation 5/10.40; PlayStation 4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15
 playstation-smarttv: Mozilla/5.0 (PlayStation 5/SmartTV) AppleWebKit/605.1.15 (KHTML, like Gecko)
 playstation-vita: Mozilla/5.0 (PlayStation Vita 3.74) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2
+webos: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.34 Safari/537.36 DMOST/1.0.1 (; LGE; webOSTV; WEBOS4.1.0 04.10.40; W4_lm18a;)
+webos-hp: Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.5; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/234.83 Safari/534.6 TouchPad/1.0
 windows-10: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Atom/1.6.2 Chrome/45.0.2454.85 Electron/0.34.5 Safari/537.36
 windows-7: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0; Wildfire NoTrail; ProE-Datecode:3302014090)
 windows-8: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) your-app/0.1.0 Chrome/41.0.2272.76 Electron/0.24.0 Safari/537.36

--- a/assets/test/platforms.yml
+++ b/assets/test/platforms.yml
@@ -67,6 +67,7 @@ ios-8: Mozilla/5.0 (iPhone; CPU iPhone OS 8_7_2; like Mac OS X) AppleWebKit/535.
 ios-app: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B93 Electron/like MathspaceIOS/2.7.2
 kai-os-1: Mozilla/5.0 (Mobile; ALCATEL4044T; rv:37.0) Gecko/37.0 Firefox/37.0 KaiOS/1.0
 kai-os-2: Mozilla/5.0 (Mobile; LYF/LF-2403N/LYF-LF2403N-000-01-18IMEI-040817-i; rv:48.0) Gecko/48.0 Firefox/48.0 KaiOS/2.0
+kindle: Mozilla/5.0 (Linux; U; Android 4.4; en-US; Amazon Kindle Fire HD Build/KRT16S) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.10.1227 Mobile Safari/537.36
 linux: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Atom/1.0.15 Chrome/43.0.2357.65 Electron/0.30.6 Safari/537.36
 mac-os: XMind/10.2.1.202007271856 (darwin.x64; macOS Arch/x64 Version/11.0.1; en-US) Electron/5.0.13
 mac-os-1: MOZILLA/5.0 (MACINTOSH; INTEL MAC OS X 10_14_6) APPLEWEBKIT/537.36 (KHTML LIKE GECKO) CHROME/94.0.4606.61 SAFARI/537.36

--- a/assets/test/platforms.yml
+++ b/assets/test/platforms.yml
@@ -71,6 +71,11 @@ linux: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) At
 mac-os: XMind/10.2.1.202007271856 (darwin.x64; macOS Arch/x64 Version/11.0.1; en-US) Electron/5.0.13
 mac-os-1: MOZILLA/5.0 (MACINTOSH; INTEL MAC OS X 10_14_6) APPLEWEBKIT/537.36 (KHTML LIKE GECKO) CHROME/94.0.4606.61 SAFARI/537.36
 mac-os-x: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11) AppleWebKit/537.36 (KHTML, like Gecko) NativefierPlaceholder/0.0.1 Chrome/47.0.2526.73 Electron/0.36.4 Safari/537.36
+playstation-3: Mozilla/5.0 (PLAYSTATION 3 4.91) AppleWebKit/531.22.8 (KHTML, like Gecko)
+playstation-4: Mozilla/5.0 (PlayStation; PlayStation 4/12.00) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15
+playstation-5: Mozilla/5.0 (PlayStation; PlayStation 5/10.40; PlayStation 4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15
+playstation-smarttv: Mozilla/5.0 (PlayStation 5/SmartTV) AppleWebKit/605.1.15 (KHTML, like Gecko)
+playstation-vita: Mozilla/5.0 (PlayStation Vita 3.74) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2
 windows-10: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Atom/1.6.2 Chrome/45.0.2454.85 Electron/0.34.5 Safari/537.36
 windows-7: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0; Wildfire NoTrail; ProE-Datecode:3302014090)
 windows-8: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) your-app/0.1.0 Chrome/41.0.2272.76 Electron/0.24.0 Safari/537.36

--- a/browser.go
+++ b/browser.go
@@ -70,6 +70,7 @@ func (b *Browser) register() {
 	matchers := []BrowserMatcher{
 		matchers.NewAlipay(parser),
 		matchers.NewNokia(parser),
+		matchers.NewNintendo(parser),
 		matchers.NewUCBrowser(parser),
 		matchers.NewBlackBerry(parser),
 		matchers.NewBrave(parser),
@@ -185,6 +186,15 @@ func (b *Browser) IsAndroidBrowser() bool {
 // https://www.alipay.com/
 func (b *Browser) IsAlipay() bool {
 	if _, ok := b.getMatcher().(*matchers.Alipay); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsNintendo returns true if the browser is Nintendo.
+func (b *Browser) IsNintendo() bool {
+	if _, ok := b.getMatcher().(*matchers.Nintendo); ok {
 		return true
 	}
 

--- a/browser.go
+++ b/browser.go
@@ -72,6 +72,7 @@ func (b *Browser) register() {
 		matchers.NewNokia(parser),
 		matchers.NewNintendo(parser),
 		matchers.NewUCBrowser(parser),
+		matchers.NewBaidu(parser),
 		matchers.NewBlackBerry(parser),
 		matchers.NewBrave(parser),
 		matchers.NewOpera(parser),
@@ -186,6 +187,17 @@ func (b *Browser) IsAndroidBrowser() bool {
 // https://www.alipay.com/
 func (b *Browser) IsAlipay() bool {
 	if _, ok := b.getMatcher().(*matchers.Alipay); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsBaidu returns true if the browser is Baidu.
+//
+// http://liulanqi.baidu.com/
+func (b *Browser) IsBaidu() bool {
+	if _, ok := b.getMatcher().(*matchers.Baidu); ok {
 		return true
 	}
 

--- a/browser.go
+++ b/browser.go
@@ -101,6 +101,7 @@ func (b *Browser) register() {
 		matchers.NewYaaniBrowser(parser),
 		matchers.NewYandex(parser),
 		matchers.NewFirefox(parser),
+		matchers.NewAndroidBrowser(parser),
 		matchers.NewChrome(parser), // chrome should be before safari
 		matchers.NewSafari(parser), // chrome and safari must be at the end
 		matchers.NewUnknown(parser),
@@ -164,6 +165,19 @@ func (b *Browser) Device() *Device {
 // Bot returns the bot of the browser.
 func (b *Browser) Bot() *Bot {
 	return b.bot
+}
+
+// IsAndroidBrowser returns true if the browser is Android Browser
+//
+// Android WebView on Android >= 4.4 is purposefully being identified as Chrome
+//
+// https://developer.chrome.com/multidevice/webview/overview
+func (b *Browser) IsAndroidBrowser() bool {
+	if _, ok := b.getMatcher().(*matchers.AndroidBrowser); ok {
+		return true
+	}
+
+	return false
 }
 
 // IsAliPay returns true if the browser is AliPay.

--- a/browser.go
+++ b/browser.go
@@ -92,6 +92,7 @@ func (b *Browser) register() {
 		matchers.NewEdge(parser),
 		matchers.NewInternetExplorer(parser),
 		matchers.NewSamsungBrowser(parser),
+		matchers.NewSilkBrowser(parser),
 		matchers.NewSogouBrowser(parser),
 		matchers.NewVivaldi(parser),
 		matchers.NewVivoBrowser(parser),
@@ -429,6 +430,17 @@ func (b *Browser) IsInternetExplorer() bool {
 // IsSamsungBrowser returns true if the browser is SamsungBrowser.
 func (b *Browser) IsSamsungBrowser() bool {
 	if _, ok := b.getMatcher().(*matchers.SamsungBrowser); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsSilkBrowser returns true if the browser is Amazon Silk browser.
+//
+// https://docs.aws.amazon.com/silk/
+func (b *Browser) IsSilkBrowser() bool {
+	if _, ok := b.getMatcher().(*matchers.SilkBrowser); ok {
 		return true
 	}
 

--- a/browser.go
+++ b/browser.go
@@ -93,6 +93,7 @@ func (b *Browser) register() {
 		matchers.NewInternetExplorer(parser),
 		matchers.NewSamsungBrowser(parser),
 		matchers.NewSilkBrowser(parser),
+		matchers.NewCocCoc(parser),
 		matchers.NewSogouBrowser(parser),
 		matchers.NewVivaldi(parser),
 		matchers.NewVivoBrowser(parser),
@@ -441,6 +442,17 @@ func (b *Browser) IsSamsungBrowser() bool {
 // https://docs.aws.amazon.com/silk/
 func (b *Browser) IsSilkBrowser() bool {
 	if _, ok := b.getMatcher().(*matchers.SilkBrowser); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsCocCoc returns true if the browser is Coc Coc.
+//
+// https://coccoc.com/en/
+func (b *Browser) IsCocCoc() bool {
+	if _, ok := b.getMatcher().(*matchers.CocCoc); ok {
 		return true
 	}
 

--- a/browser_test.go
+++ b/browser_test.go
@@ -784,6 +784,26 @@ func TestBrowserIsSamsungBrowser(t *testing.T) {
 	})
 }
 
+func TestBrowserIsSilkBrowser(t *testing.T) {
+	Convey("Subject: #IsSilkBrowser", t, func() {
+		Convey("When the browser is Silk Browser", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["silk-browser"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsSilkBrowser(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the browser is not Silk Browser", func() {
+			Convey("It should return false", func() {
+				ua := testUserAgents["chrome"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsSilkBrowser(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
 func TestBrowserIsSougouBrowser(t *testing.T) {
 	Convey("Subject: #IsSougouBrowser", t, func() {
 		Convey("When the browser is Sougou Browser", func() {

--- a/browser_test.go
+++ b/browser_test.go
@@ -317,6 +317,26 @@ func TestBrowserIsAlipay(t *testing.T) {
 	})
 }
 
+func TestBrowserIsAndroidBrowser(t *testing.T) {
+	Convey("Subject: #IsAndroidBrowser", t, func() {
+		Convey("When the browser is Android Browser", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["android-browser"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsAndroidBrowser(), ShouldBeTrue)
+			})
+
+			Convey("When the browser is not Android Browser", func() {
+				Convey("It should return false", func() {
+					ua := testUserAgents["chrome"]
+					b, _ := NewBrowser(ua.Android)
+					So(b.IsAndroidBrowser(), ShouldBeFalse)
+				})
+			})
+		})
+	})
+}
+
 func TestBrowserIsNokia(t *testing.T) {
 	Convey("Subject: #IsNokia", t, func() {
 		Convey("When the browser is Nokia", func() {

--- a/browser_test.go
+++ b/browser_test.go
@@ -357,6 +357,26 @@ func TestBrowserIsNokia(t *testing.T) {
 	})
 }
 
+func TestBrowserIsNintendo(t *testing.T) {
+	Convey("Subject: #IsNintendo", t, func() {
+		Convey("When the browser is Nintendo", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["nintendo"]
+				b, _ := NewBrowser(ua.Linux)
+				So(b.IsNintendo(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the browser is not Nintendo", func() {
+			Convey("It should return false", func() {
+				ua := testUserAgents["chrome"]
+				b, _ := NewBrowser(ua.Linux)
+				So(b.IsNintendo(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
 func TestBrowserIsUCBrowser(t *testing.T) {
 	Convey("Subject: #IsUCBrowser", t, func() {
 		Convey("When the browser is UC Browser", func() {

--- a/browser_test.go
+++ b/browser_test.go
@@ -1046,3 +1046,23 @@ func TestBrowserIsVivaldi(t *testing.T) {
 		})
 	})
 }
+
+func TestBrowserIsCocCoc(t *testing.T) {
+	Convey("Subject: #IsCocCoc", t, func() {
+		Convey("When the browser is Coc Coc", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["coc-coc"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsCocCoc(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the browser is not CocCoc", func() {
+			Convey("It should return false", func() {
+				ua := testUserAgents["chrome"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsCocCoc(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/browser_test.go
+++ b/browser_test.go
@@ -337,6 +337,26 @@ func TestBrowserIsAndroidBrowser(t *testing.T) {
 	})
 }
 
+func TestBrowserIsBaidu(t *testing.T) {
+	Convey("Subject: #IsBaidu", t, func() {
+		Convey("When the browser is Baidu", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["baidu"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsBaidu(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the browser is not Baidu", func() {
+			Convey("It should return false", func() {
+				ua := testUserAgents["chrome"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsBaidu(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
 func TestBrowserIsNokia(t *testing.T) {
 	Convey("Subject: #IsNokia", t, func() {
 		Convey("When the browser is Nokia", func() {

--- a/device.go
+++ b/device.go
@@ -46,8 +46,8 @@ func (d *Device) register() {
 	// define all your device matchers here
 	matchers := []DeviceMatcher{
 		devices.NewBlackberryPlaybook(parser),
+		devices.NewIpad(parser), // iPad should come before iPhone for ipad-6 example
 		devices.NewIphone(parser),
-		devices.NewIpad(parser),
 		devices.NewIpodTouch(parser),
 		devices.NewKindleFire(parser),
 		devices.NewKindle(parser),

--- a/device_test.go
+++ b/device_test.go
@@ -308,14 +308,16 @@ func TestDeviceIsTV(t *testing.T) {
 	Convey("Given a user agent string", t, func() {
 		Convey("When the device is a TV", func() {
 			Convey("It should return true", func() {
-				d, _ := NewDevice(testDevices["tv-1"])
-				So(d.IsTV(), ShouldBeTrue)
+				for _, ua := range []string{testDevices["tv-1"], testDevices["tv-2"], testDevices["tv-3"]} {
+					d, _ := NewDevice(ua)
+					So(d.IsTV(), ShouldBeTrue)
+				}
 			})
 		})
 
 		Convey("When the device is not a TV", func() {
 			Convey("It should return false", func() {
-				d, _ := NewDevice(testDevices["iphone-7"])
+				d, _ := NewDevice(testDevices["android-12"])
 				So(d.IsTV(), ShouldBeFalse)
 			})
 		})

--- a/device_test.go
+++ b/device_test.go
@@ -349,9 +349,10 @@ func TestDeviceIsTablet(t *testing.T) {
 	Convey("Given a user agent string", t, func() {
 		Convey("When the device is a tablet", func() {
 			Convey("It should return true", func() {
-				tablets := []string{testDevices["ipad-4"], testDevices["surface-1"], testDevices["bb-playbook-1"]}
-				for _, ua := range tablets {
-					d, _ := NewDevice(ua)
+				tablets := []string{"ipad-4", "surface-1", "bb-playbook-1", "ipad-6"}
+				for _, device := range tablets {
+					tablet := testDevices[device]
+					d, _ := NewDevice(tablet)
 					So(d.IsTablet(), ShouldBeTrue)
 				}
 			})

--- a/devices/ipad_test.go
+++ b/devices/ipad_test.go
@@ -30,6 +30,7 @@ func TestIpadMatch(t *testing.T) {
 				So(NewIpad(NewUAParser(testDevices["ipad-3"])).Match(), ShouldBeTrue)
 				So(NewIpad(NewUAParser(testDevices["ipad-4"])).Match(), ShouldBeTrue)
 				So(NewIpad(NewUAParser(testDevices["ipad-5"])).Match(), ShouldBeTrue)
+				So(NewIpad(NewUAParser(testDevices["ipad-6"])).Match(), ShouldBeTrue)
 			})
 		})
 

--- a/devices/tv.go
+++ b/devices/tv.go
@@ -6,7 +6,7 @@ type TV struct {
 
 var (
 	tvName       = "TV"
-	tvMatchRegex = []string{`(?i)(\btv|Android.*?ADT-1|Nexus Player)`}
+	tvMatchRegex = []string{`(?i)(\btv|Android.*?ADT-1|Nexus Player|SmartTV)`}
 )
 
 func NewTV(p Parser) *TV {

--- a/matchers/android_browser.go
+++ b/matchers/android_browser.go
@@ -1,0 +1,33 @@
+package matchers
+
+import "strings"
+
+type AndroidBrowser struct {
+	p Parser
+}
+
+var (
+	androidBrowserName          = "Android Browser"
+	androidBrowserVersionRegexp = []string{`Version/([\d.]+)`}
+)
+
+func NewAndroidBrowser(p Parser) *AndroidBrowser {
+	return &AndroidBrowser{
+		p: p,
+	}
+}
+
+func (b *AndroidBrowser) Name() string {
+	return androidBrowserName
+}
+
+func (b *AndroidBrowser) Version() string {
+	return b.p.Version(androidBrowserVersionRegexp, 1)
+}
+
+func (b *AndroidBrowser) Match() bool {
+	// Without lookbehinds in Go regexp library, it is much easier to use strings.Contains
+	ua := strings.ToLower(b.p.String())
+
+	return strings.Contains(ua, "android") && !strings.Contains(ua, "chrome/") && strings.Contains(ua, "version/") && !strings.Contains(ua, "like android")
+}

--- a/matchers/android_browser_test.go
+++ b/matchers/android_browser_test.go
@@ -1,0 +1,62 @@
+package matchers
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewAndroidBrowser(t *testing.T) {
+	Convey("Subject: #NewAndroidBrowser", t, func() {
+		Convey("It should return a new Android Browser instance", func() {
+			So(NewAndroidBrowser(NewUAParser("")), ShouldHaveSameTypeAs, &AndroidBrowser{})
+		})
+	})
+}
+
+func TestAndroidBrowserName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return AndroidBrowser", func() {
+			sb := NewAndroidBrowser(NewUAParser(""))
+			So(sb.Name(), ShouldEqual, "Android Browser")
+		})
+	})
+}
+
+func TestAndroidBrowserVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It should return the version", func() {
+				sb := testUserAgents["android-browser"]
+
+				So(NewAndroidBrowser(NewUAParser(sb.Android)).Version(), ShouldEqual, "4.0")
+			})
+		})
+
+		Convey("When the version is not matched", func() {
+			Convey("It should return default version", func() {
+				sb := NewAndroidBrowser(NewUAParser("Mozilla/5.0 (Linux; Android 4.4.2; SM-G900F Build/KOT49H)"))
+				So(sb.Version(), ShouldEqual, "0.0")
+			})
+		})
+	})
+}
+
+func TestAndroidBrowserMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Android Browser", func() {
+			Convey("It should return true", func() {
+				sb := testUserAgents["android-browser"]
+
+				So(NewAndroidBrowser(NewUAParser(sb.Android)).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Android Browser", func() {
+			Convey("It should return false", func() {
+				sb := NewAndroidBrowser(NewUAParser(testUserAgents["chrome"].Android))
+				So(sb.Match(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/matchers/baidu.go
+++ b/matchers/baidu.go
@@ -1,0 +1,29 @@
+package matchers
+
+type Baidu struct {
+	p Parser
+}
+
+var (
+	baiduName          = "Baidu"
+	baiduVersionRegexp = []string{`baiduboxapp/([\d.]+)`}
+	baiduMatchRegex    = []string{`(?i)baiduboxapp`}
+)
+
+func NewBaidu(p Parser) *Baidu {
+	return &Baidu{
+		p: p,
+	}
+}
+
+func (a *Baidu) Name() string {
+	return baiduName
+}
+
+func (a *Baidu) Version() string {
+	return a.p.Version(baiduVersionRegexp, 1)
+}
+
+func (a *Baidu) Match() bool {
+	return a.p.Match(baiduMatchRegex)
+}

--- a/matchers/baidu_test.go
+++ b/matchers/baidu_test.go
@@ -1,0 +1,59 @@
+package matchers
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewBaidu(t *testing.T) {
+	Convey("Subject: #NewBaidu", t, func() {
+		Convey("It should return a new Baidu instance", func() {
+			baidu := NewBaidu(NewUAParser(""))
+			So(baidu, ShouldHaveSameTypeAs, &Baidu{})
+		})
+	})
+}
+
+func TestBaiduName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return the correct name", func() {
+			baidu := NewBaidu(NewUAParser(""))
+			So(baidu.Name(), ShouldEqual, "Baidu")
+		})
+	})
+}
+
+func TestBaiduVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is captured", func() {
+			Convey("It should return the version", func() {
+				ua := testUserAgents["baidu"]
+
+				So(NewBaidu(NewUAParser(ua.IOS)).Version(), ShouldEqual, "13.81.1.10")
+				So(NewBaidu(NewUAParser(ua.Android)).Version(), ShouldEqual, "13.81.1.10")
+			})
+		})
+
+	})
+}
+
+func TestBaiduMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Baidu", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["baidu"]
+				So(NewBaidu(NewUAParser(ua.IOS)).Match(), ShouldBeTrue)
+				So(NewBaidu(NewUAParser(ua.Android)).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Baidu", func() {
+			Convey("It should return false", func() {
+				ua := "Mozilla/5.0 (Linux; Android 10; Redmi K30 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.101 Mobile Safari/537.36"
+				baidu := NewBaidu(NewUAParser(ua))
+				So(baidu.Match(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/matchers/coc_coc.go
+++ b/matchers/coc_coc.go
@@ -1,0 +1,33 @@
+package matchers
+
+type CocCoc struct {
+	p Parser
+}
+
+var (
+	cocCocName         = "Coc Coc"
+	cocCocVersionRegex = []string{
+		`(?i)coc_coc_browser/([\d.]+)`,
+		`Chrome/([\d.]+)`,
+		`Safari/([\d.]+)`,
+	}
+	cocCocMatchRegex = []string{`coc_coc_browser/`}
+)
+
+func NewCocCoc(p Parser) *CocCoc {
+	return &CocCoc{
+		p: p,
+	}
+}
+
+func (s *CocCoc) Name() string {
+	return cocCocName
+}
+
+func (s *CocCoc) Version() string {
+	return s.p.Version(cocCocVersionRegex, 1)
+}
+
+func (s *CocCoc) Match() bool {
+	return s.p.Match(cocCocMatchRegex)
+}

--- a/matchers/coc_coc_test.go
+++ b/matchers/coc_coc_test.go
@@ -1,0 +1,66 @@
+package matchers
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewCocCoc(t *testing.T) {
+	Convey("Subject: #NewCocCoc", t, func() {
+		Convey("It should return a new CocCoc instance", func() {
+			So(NewCocCoc(NewUAParser("")), ShouldHaveSameTypeAs, &CocCoc{})
+		})
+	})
+}
+
+func TestCocCocName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Coc Coc", func() {
+			sb := NewCocCoc(NewUAParser(""))
+			So(sb.Name(), ShouldEqual, "Coc Coc")
+		})
+	})
+}
+
+func TestCocCocVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It should return the version", func() {
+				sb := testUserAgents["coc-coc"]
+
+				So(NewCocCoc(NewUAParser(sb.Android)).Version(), ShouldEqual, "80.0.232")
+				So(NewCocCoc(NewUAParser(sb.Mac)).Version(), ShouldEqual, "94.0.210")
+				So(NewCocCoc(NewUAParser(sb.Windows)).Version(), ShouldEqual, "56.3.162")
+			})
+		})
+
+		Convey("When the version is not matched", func() {
+			Convey("It should return default version", func() {
+				sb := NewCocCoc(NewUAParser("Mozilla/5.0 (Linux; Android 4.4.2; SM-G900F Build/KOT49H)"))
+				So(sb.Version(), ShouldEqual, "0.0")
+			})
+		})
+	})
+}
+
+func TestCocCocMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Coc Coc", func() {
+			Convey("It should return true", func() {
+				sb := testUserAgents["coc-coc"]
+
+				So(NewCocCoc(NewUAParser(sb.Android)).Match(), ShouldBeTrue)
+				So(NewCocCoc(NewUAParser(sb.Mac)).Match(), ShouldBeTrue)
+				So(NewCocCoc(NewUAParser(sb.Windows)).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Silk Browser", func() {
+			Convey("It should return false", func() {
+				sb := NewCocCoc(NewUAParser(testUserAgents["chrome"].Android))
+				So(sb.Match(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/matchers/coc_coc_test.go
+++ b/matchers/coc_coc_test.go
@@ -56,7 +56,7 @@ func TestCocCocMatch(t *testing.T) {
 			})
 		})
 
-		Convey("When user agent does not match Silk Browser", func() {
+		Convey("When user agent does not match Coc Coc", func() {
 			Convey("It should return false", func() {
 				sb := NewCocCoc(NewUAParser(testUserAgents["chrome"].Android))
 				So(sb.Match(), ShouldBeFalse)

--- a/matchers/nintendo.go
+++ b/matchers/nintendo.go
@@ -1,0 +1,29 @@
+package matchers
+
+type Nintendo struct {
+	p Parser
+}
+
+var (
+	nintendoName          = "Nintendo"
+	nintendoVersionRegexp = []string{`NintendoBrowser/([\d.]+)`}
+	nintendoMatchRegexp   = []string{`NintendoBrowser`}
+)
+
+func NewNintendo(p Parser) *Nintendo {
+	return &Nintendo{
+		p: p,
+	}
+}
+
+func (n *Nintendo) Name() string {
+	return nintendoName
+}
+
+func (n *Nintendo) Version() string {
+	return n.p.Version(nintendoVersionRegexp, 1)
+}
+
+func (n *Nintendo) Match() bool {
+	return n.p.Match(nintendoMatchRegexp)
+}

--- a/matchers/nintendo_test.go
+++ b/matchers/nintendo_test.go
@@ -1,0 +1,62 @@
+package matchers
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewNintendo(t *testing.T) {
+	Convey("Subject: #NewNintendo", t, func() {
+		Convey("It should return a new Nintendo instance", func() {
+			So(NewNintendo(NewUAParser("")), ShouldHaveSameTypeAs, &Nintendo{})
+		})
+	})
+}
+
+func TestNintendoName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Nintendo", func() {
+			n := NewNintendo(NewUAParser(""))
+			So(n.Name(), ShouldEqual, "Nintendo")
+		})
+	})
+}
+
+func TestNintendoVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		ua := testUserAgents["nintendo"]
+		Convey("When the version is matched", func() {
+			Convey("It should return the version", func() {
+				So(NewNintendo(NewUAParser(ua.Linux)).Version(), ShouldEqual, "5.1.0.23653")
+			})
+		})
+	})
+
+	Convey("When the version is not matched", t, func() {
+		Convey("It should return default version", func() {
+			n := NewNintendo(NewUAParser(testUserAgents["chrome"].Linux))
+			So(n.Version(), ShouldEqual, "0.0")
+		})
+	})
+}
+
+func TestNintendoMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Nintendo", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["nintendo"]
+
+				So(NewNintendo(NewUAParser(ua.Linux)).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Nintendo", func() {
+			Convey("It should return false", func() {
+				ua := testUserAgents["chrome"]
+
+				So(NewNintendo(NewUAParser(ua.Linux)).Match(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/matchers/silk_browser.go
+++ b/matchers/silk_browser.go
@@ -1,0 +1,33 @@
+package matchers
+
+type SilkBrowser struct {
+	p Parser
+}
+
+var (
+	silkBrowserName         = "Silk"
+	silkBrowserVersionRegex = []string{
+		`(?i)Silk/([\d.]+)`,
+		`Chrome/([\d.]+)`,
+		`Safari/([\d.]+)`,
+	}
+	silkBrowserMatchRegex = []string{`Silk/`}
+)
+
+func NewSilkBrowser(p Parser) *SilkBrowser {
+	return &SilkBrowser{
+		p: p,
+	}
+}
+
+func (s *SilkBrowser) Name() string {
+	return silkBrowserName
+}
+
+func (s *SilkBrowser) Version() string {
+	return s.p.Version(silkBrowserVersionRegex, 1)
+}
+
+func (s *SilkBrowser) Match() bool {
+	return s.p.Match(silkBrowserMatchRegex)
+}

--- a/matchers/silk_browser_test.go
+++ b/matchers/silk_browser_test.go
@@ -1,0 +1,62 @@
+package matchers
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewSilkBrowser(t *testing.T) {
+	Convey("Subject: #NewSilkBrowser", t, func() {
+		Convey("It should return a new SilkBrowser instance", func() {
+			So(NewSilkBrowser(NewUAParser("")), ShouldHaveSameTypeAs, &SilkBrowser{})
+		})
+	})
+}
+
+func TestSilkBrowserName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Silk", func() {
+			sb := NewSilkBrowser(NewUAParser(""))
+			So(sb.Name(), ShouldEqual, "Silk")
+		})
+	})
+}
+
+func TestSilkBrowserVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It should return the version", func() {
+				sb := testUserAgents["silk-browser"]
+
+				So(NewSilkBrowser(NewUAParser(sb.Android)).Version(), ShouldEqual, "130.5.9")
+			})
+		})
+
+		Convey("When the version is not matched", func() {
+			Convey("It should return default version", func() {
+				sb := NewSilkBrowser(NewUAParser("Mozilla/5.0 (Linux; Android 4.4.2; SM-G900F Build/KOT49H)"))
+				So(sb.Version(), ShouldEqual, "0.0")
+			})
+		})
+	})
+}
+
+func TestSilkBrowserMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Silk Browser", func() {
+			Convey("It should return true", func() {
+				sb := testUserAgents["silk-browser"]
+
+				So(NewSilkBrowser(NewUAParser(sb.Android)).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Silk Browser", func() {
+			Convey("It should return false", func() {
+				sb := NewSilkBrowser(NewUAParser(testUserAgents["chrome"].Linux))
+				So(sb.Match(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/platform.go
+++ b/platform.go
@@ -57,6 +57,7 @@ func (p *Platform) register() {
 		platforms.NewLinux(parser),
 		platforms.NewFirefoxOS(parser),
 		platforms.NewChromeOS(parser),
+		platforms.NewPlaystation(parser),
 		platforms.NewUnknown(parser),
 	}
 
@@ -168,6 +169,15 @@ func (p *Platform) IsLinux() bool {
 // IsBlackBerry returns true if platform is BlackBerry.
 func (p *Platform) IsBlackBerry() bool {
 	if _, ok := p.getMatcher().(*platforms.BlackBerry); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsPlaystation returns true if platform is PlayStation
+func (p *Platform) IsPlaystation() bool {
+	if _, ok := p.getMatcher().(*platforms.Playstation); ok {
 		return true
 	}
 

--- a/platform.go
+++ b/platform.go
@@ -58,6 +58,7 @@ func (p *Platform) register() {
 		platforms.NewLinux(parser),
 		platforms.NewFirefoxOS(parser),
 		platforms.NewChromeOS(parser),
+		platforms.NewNintendo(parser),
 		platforms.NewPlaystation(parser),
 		platforms.NewUnknown(parser),
 	}
@@ -179,6 +180,15 @@ func (p *Platform) IsLinux() bool {
 // IsBlackBerry returns true if platform is BlackBerry.
 func (p *Platform) IsBlackBerry() bool {
 	if _, ok := p.getMatcher().(*platforms.BlackBerry); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsLinux returns true if the platform is Nintendo.
+func (p *Platform) IsNintendo() bool {
+	if _, ok := p.getMatcher().(*platforms.Nintendo); ok {
 		return true
 	}
 

--- a/platform.go
+++ b/platform.go
@@ -52,6 +52,7 @@ func (p *Platform) register() {
 		platforms.NewWatchOS(parser),
 		platforms.NewWindowsMobile(parser),
 		platforms.NewWindowsPhone(parser),
+		platforms.NewXbox(parser), // Should come before Windows
 		platforms.NewWindows(parser),
 		platforms.NewKindle(parser), // Should come before Android
 		platforms.NewAndroid(parser),
@@ -351,5 +352,14 @@ func (p *Platform) IsWindowsTouchScreenDesktop() bool {
 	if p.IsWindows() && strings.Contains(p.userAgent, "Touch") {
 		return true
 	}
+	return false
+}
+
+// IsXbox returns true if the platform is Xbox.
+func (p *Platform) IsXbox() bool {
+	if _, ok := p.getMatcher().(*platforms.Xbox); ok {
+		return true
+	}
+
 	return false
 }

--- a/platform.go
+++ b/platform.go
@@ -48,11 +48,11 @@ func (p *Platform) register() {
 		platforms.NewAdobeAir(parser),
 		platforms.NewBlackBerry(parser),
 		platforms.NewKaiOS(parser),
+		platforms.NewWindowsPhone(parser), // Should come before iOS because of window-phone-2 example
 		platforms.NewIOS(parser),
 		platforms.NewMac(parser),
 		platforms.NewWatchOS(parser),
 		platforms.NewWindowsMobile(parser),
-		platforms.NewWindowsPhone(parser),
 		platforms.NewXbox(parser), // Should come before Windows
 		platforms.NewWindows(parser),
 		platforms.NewKindle(parser), // Should come before Android

--- a/platform.go
+++ b/platform.go
@@ -53,6 +53,7 @@ func (p *Platform) register() {
 		platforms.NewWindowsMobile(parser),
 		platforms.NewWindowsPhone(parser),
 		platforms.NewWindows(parser),
+		platforms.NewKindle(parser), // Should come before Android
 		platforms.NewAndroid(parser),
 		platforms.NewLinux(parser),
 		platforms.NewFirefoxOS(parser),
@@ -151,6 +152,15 @@ func (p *Platform) IsWatchOS() bool {
 // IsKaiOS returns true if the user agent string matches KaiOS.
 func (p *Platform) IsKaiOS() bool {
 	if _, ok := p.getMatcher().(*platforms.KaiOS); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsKindle returns true if the user agent string matches Kindle.
+func (p *Platform) IsKindle() bool {
+	if _, ok := p.getMatcher().(*platforms.Kindle); ok {
 		return true
 	}
 

--- a/platform.go
+++ b/platform.go
@@ -55,6 +55,7 @@ func (p *Platform) register() {
 		platforms.NewXbox(parser), // Should come before Windows
 		platforms.NewWindows(parser),
 		platforms.NewKindle(parser), // Should come before Android
+		platforms.NewWebOS(parser),  // Should come before Android
 		platforms.NewAndroid(parser),
 		platforms.NewLinux(parser),
 		platforms.NewFirefoxOS(parser),
@@ -358,6 +359,15 @@ func (p *Platform) IsWindowsTouchScreenDesktop() bool {
 // IsXbox returns true if the platform is Xbox.
 func (p *Platform) IsXbox() bool {
 	if _, ok := p.getMatcher().(*platforms.Xbox); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsXbox returns true if the platform is WebOS.
+func (p *Platform) IsWebOS() bool {
+	if _, ok := p.getMatcher().(*platforms.WebOS); ok {
 		return true
 	}
 

--- a/platform.go
+++ b/platform.go
@@ -49,6 +49,7 @@ func (p *Platform) register() {
 		platforms.NewBlackBerry(parser),
 		platforms.NewKaiOS(parser),
 		platforms.NewIOS(parser),
+		platforms.NewMac(parser),
 		platforms.NewWatchOS(parser),
 		platforms.NewWindowsMobile(parser),
 		platforms.NewWindowsPhone(parser),
@@ -368,6 +369,15 @@ func (p *Platform) IsXbox() bool {
 // IsXbox returns true if the platform is WebOS.
 func (p *Platform) IsWebOS() bool {
 	if _, ok := p.getMatcher().(*platforms.WebOS); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsMac returns true if the platform is MacOS
+func (p *Platform) IsMac() bool {
+	if _, ok := p.getMatcher().(*platforms.Mac); ok {
 		return true
 	}
 

--- a/platform_test.go
+++ b/platform_test.go
@@ -273,6 +273,24 @@ func TestPlatformIsLinux(t *testing.T) {
 	})
 }
 
+func TestPlatformIsNintendo(t *testing.T) {
+	Convey("Given a user agent string", t, func() {
+		Convey("When the platform is Nintendo", func() {
+			p, _ := NewPlatform(testPlatforms["nintendo"])
+			Convey("It returns true", func() {
+				So(p.IsNintendo(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the platform is not Nintendo", func() {
+			p, _ := NewPlatform(testPlatforms["linux"])
+			Convey("It returns false", func() {
+				So(p.IsNintendo(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
 func TestPlatformIsBlackberry(t *testing.T) {
 	Convey("Given a user agent string", t, func() {
 		Convey("When the platform is BlackBerry", func() {

--- a/platform_test.go
+++ b/platform_test.go
@@ -237,6 +237,24 @@ func TestPlatformIsKaiOS(t *testing.T) {
 	})
 }
 
+func TestPlatformIsKindle(t *testing.T) {
+	Convey("Given a user agent string", t, func() {
+		Convey("When the platform is Kindle", func() {
+			p, _ := NewPlatform(testPlatforms["kindle"])
+			Convey("It returns true", func() {
+				So(p.IsKindle(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the platform is not Kindle", func() {
+			p, _ := NewPlatform(testPlatforms["blackberry"])
+			Convey("It returns false", func() {
+				So(p.IsKindle(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
 func TestPlatformIsLinux(t *testing.T) {
 	Convey("Given a user agent string", t, func() {
 		Convey("When the platform is Linux", func() {

--- a/platform_test.go
+++ b/platform_test.go
@@ -634,3 +634,24 @@ func TestPlatformIsWindowsTouchScreenDesktop(t *testing.T) {
 		})
 	})
 }
+
+func TestPlatformIsXbox(t *testing.T) {
+	Convey("Given a user agent string", t, func() {
+		Convey("When the platform is Xbox", func() {
+			p, _ := NewPlatform(testPlatforms["xbox"])
+			Convey("It returns true", func() {
+				So(p.IsXbox(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the platform is not Xbox", func() {
+			Convey("It returns false", func() {
+				platforms := []string{"windows-10", "windows-8", "windows-7", "windows-xp"}
+				for _, platform := range platforms {
+					p, _ := NewPlatform(testPlatforms[platform])
+					So(p.IsXbox(), ShouldBeFalse)
+				}
+			})
+		})
+	})
+}

--- a/platform_test.go
+++ b/platform_test.go
@@ -351,10 +351,10 @@ func TestPlatformIsWindowsMobile(t *testing.T) {
 func TestPlatformIsWindowsPhone(t *testing.T) {
 	Convey("Given a user agent string", t, func() {
 		Convey("When the platform is Windows Phone", func() {
-			p, _ := NewPlatform(testPlatforms["windows-phone"])
-			Convey("It returns true", func() {
+			for _, platform := range []string{"windows-phone-1", "windows-phone-2"} {
+				p, _ := NewPlatform(testPlatforms[platform])
 				So(p.IsWindowsPhone(), ShouldBeTrue)
-			})
+			}
 		})
 
 		Convey("When the platform is not Windows Phone", func() {

--- a/platform_test.go
+++ b/platform_test.go
@@ -655,3 +655,22 @@ func TestPlatformIsXbox(t *testing.T) {
 		})
 	})
 }
+
+func TestPlatformIsWebOS(t *testing.T) {
+	Convey("Given a user agent string", t, func() {
+		Convey("When the platform is WebOS", func() {
+			platforms := []string{"webos", "webos-hp"}
+			for _, platform := range platforms {
+				p, _ := NewPlatform(testPlatforms[platform])
+				So(p.IsWebOS(), ShouldBeTrue)
+			}
+		})
+
+		Convey("When the platform is not WebOS", func() {
+			Convey("It returns false", func() {
+				p, _ := NewPlatform(testPlatforms["android"])
+				So(p.IsWebOS(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/platform_test.go
+++ b/platform_test.go
@@ -273,6 +273,27 @@ func TestPlatformIsBlackberry(t *testing.T) {
 	})
 }
 
+func TestPlatformIsPlaystation(t *testing.T) {
+	Convey("Given a user agent string", t, func() {
+		Convey("When the platform is Playstation", func() {
+			Convey("It returns true", func() {
+				platforms := []string{"playstation-3", "playstation-4", "playstation-5", "playstation-vita"}
+				for _, platform := range platforms {
+					p, _ := NewPlatform(testPlatforms[platform])
+					So(p.IsPlaystation(), ShouldBeTrue)
+				}
+			})
+		})
+
+		Convey("When the platform is not Playstation", func() {
+			p, _ := NewPlatform(testPlatforms["linux"])
+			Convey("It returns false", func() {
+				So(p.IsPlaystation(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
 func TestPlatformIsWindowsMobile(t *testing.T) {
 	Convey("Given a user agent string", t, func() {
 		Convey("When the platform is Windows Mobile", func() {

--- a/platform_test.go
+++ b/platform_test.go
@@ -674,3 +674,22 @@ func TestPlatformIsWebOS(t *testing.T) {
 		})
 	})
 }
+
+func TestPlatformIsMacOS(t *testing.T) {
+	Convey("Given a user agent string", t, func() {
+		Convey("When the platform is MacOS", func() {
+			platforms := []string{"mac-os", "mac-os-1", "mac-os-x"}
+			for _, platform := range platforms {
+				p, _ := NewPlatform(testPlatforms[platform])
+				So(p.IsMac(), ShouldBeTrue)
+			}
+		})
+
+		Convey("When the platform is not MacOS", func() {
+			Convey("It returns false", func() {
+				p, _ := NewPlatform(testPlatforms["ios-7"])
+				So(p.IsMac(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/platforms/kindle.go
+++ b/platforms/kindle.go
@@ -1,0 +1,29 @@
+package platforms
+
+type Kindle struct {
+	p Parser
+}
+
+var (
+	kindleName       = "Kindle"
+	kindleMatchRegex = []string{`Kindle`}
+)
+
+func NewKindle(p Parser) *Kindle {
+	return &Kindle{
+		p: p,
+	}
+}
+
+func (k *Kindle) Name() string {
+	return kindleName
+}
+
+// Version returns empty string for Kindle
+func (k *Kindle) Version() string {
+	return ""
+}
+
+func (k *Kindle) Match() bool {
+	return k.p.Match(kindleMatchRegex)
+}

--- a/platforms/kindle_test.go
+++ b/platforms/kindle_test.go
@@ -1,0 +1,55 @@
+package platforms
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewKindle(t *testing.T) {
+	Convey("Subject: #NewKindle", t, func() {
+		Convey("It should return a new Kindle instance", func() {
+			So(NewKindle(NewUAParser("")), ShouldHaveSameTypeAs, &Kindle{})
+		})
+	})
+}
+
+func TestKindleName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Kindle", func() {
+			So(NewKindle(NewUAParser("")).Name(), ShouldEqual, "Kindle")
+		})
+	})
+}
+
+func TestKindleVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It does not detect version", func() {
+				So(NewKindle(NewUAParser(testPlatforms["kindle"])).Version(), ShouldEqual, "")
+			})
+		})
+
+		Convey("When is not Kindle", func() {
+			Convey("It should return default version", func() {
+				So(NewKindle(NewUAParser(testPlatforms["firefox"])).Version(), ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func TestKindleMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Kindle", func() {
+			Convey("It should return true", func() {
+				So(NewKindle(NewUAParser(testPlatforms["kindle"])).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Kindle", func() {
+			Convey("It should return false", func() {
+				So(NewKindle(NewUAParser(testPlatforms["firefox"])).Match(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/platforms/nintendo.go
+++ b/platforms/nintendo.go
@@ -1,0 +1,29 @@
+package platforms
+
+type Nintendo struct {
+	p Parser
+}
+
+var (
+	nintendoName       = "Nintendo"
+	nintendoMatchRegex = []string{`Nintendo`}
+)
+
+func NewNintendo(p Parser) *Nintendo {
+	return &Nintendo{
+		p: p,
+	}
+}
+
+func (k *Nintendo) Name() string {
+	return nintendoName
+}
+
+// Version returns empty string for Nintendo
+func (k *Nintendo) Version() string {
+	return ""
+}
+
+func (k *Nintendo) Match() bool {
+	return k.p.Match(nintendoMatchRegex)
+}

--- a/platforms/nintendo_test.go
+++ b/platforms/nintendo_test.go
@@ -1,0 +1,55 @@
+package platforms
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewNintendo(t *testing.T) {
+	Convey("Subject: #NewNintendo", t, func() {
+		Convey("It should return a new Nintendo instance", func() {
+			So(NewNintendo(NewUAParser("")), ShouldHaveSameTypeAs, &Nintendo{})
+		})
+	})
+}
+
+func TestNintendoName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Nintendo", func() {
+			So(NewNintendo(NewUAParser("")).Name(), ShouldEqual, "Nintendo")
+		})
+	})
+}
+
+func TestNintendoVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It does not detect version", func() {
+				So(NewNintendo(NewUAParser(testPlatforms["nintendo"])).Version(), ShouldEqual, "")
+			})
+		})
+
+		Convey("When is not Nintendo", func() {
+			Convey("It should return default version", func() {
+				So(NewNintendo(NewUAParser(testPlatforms["firefox"])).Version(), ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func TestNintendoMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Nintendo", func() {
+			Convey("It should return true", func() {
+				So(NewNintendo(NewUAParser(testPlatforms["nintendo"])).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Nintendo", func() {
+			Convey("It should return false", func() {
+				So(NewNintendo(NewUAParser(testPlatforms["firefox"])).Match(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/platforms/playstation.go
+++ b/platforms/playstation.go
@@ -1,0 +1,33 @@
+package platforms
+
+type Playstation struct {
+	p Parser
+}
+
+var (
+	playstationOSName          = "Playstation"
+	playstationOSVersionRegexp = []string{`(?i)playstation(\s*(\d+|vita))?[ \/]?([\d.]+)`}
+	playstationOSMatchRegexp   = []string{`(?i)playstation`}
+)
+
+func NewPlaystation(p Parser) *Playstation {
+	return &Playstation{
+		p: p,
+	}
+}
+
+func (w *Playstation) Name() string {
+	return playstationOSName
+}
+
+func (w *Playstation) Version() string {
+	globalVersion := w.p.Version(playstationOSVersionRegexp, 1, "0.0")
+	if globalVersion == "0.0" || globalVersion == "" {
+		return "0.0"
+	}
+	return w.p.Version(playstationOSVersionRegexp, 3, "0.0")
+}
+
+func (w *Playstation) Match() bool {
+	return w.p.Match(playstationOSMatchRegexp)
+}

--- a/platforms/playstation_test.go
+++ b/platforms/playstation_test.go
@@ -1,0 +1,64 @@
+package platforms
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewPlaystation(t *testing.T) {
+	Convey("Subject: #NewPlaystation", t, func() {
+		Convey("It should return a new Playstation instance", func() {
+			So(NewPlaystation(NewUAParser("")), ShouldHaveSameTypeAs, &Playstation{})
+		})
+	})
+}
+
+func TestPlaystationName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Playstation", func() {
+			So(NewPlaystation(NewUAParser(testPlatforms["playstation-3"])).Name(), ShouldEqual, "Playstation")
+			So(NewPlaystation(NewUAParser(testPlatforms["playstation-4"])).Name(), ShouldEqual, "Playstation")
+			So(NewPlaystation(NewUAParser(testPlatforms["playstation-vita"])).Name(), ShouldEqual, "Playstation")
+		})
+	})
+}
+
+func TestPlaystationVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It should return the version", func() {
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-3"])).Version(), ShouldEqual, "4.91")
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-4"])).Version(), ShouldEqual, "12.00")
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-5"])).Version(), ShouldEqual, "10.40")
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-vita"])).Version(), ShouldEqual, "3.74")
+			})
+		})
+
+		Convey("When the version is not matched", func() {
+			Convey("It should return default version", func() {
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-smarttv"])).Version(), ShouldEqual, "0.0")
+			})
+		})
+	})
+}
+
+func TestPlaystationMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Playstation", func() {
+			Convey("It should return true", func() {
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-3"])).Match(), ShouldBeTrue)
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-4"])).Match(), ShouldBeTrue)
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-5"])).Match(), ShouldBeTrue)
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-smarttv"])).Match(), ShouldBeTrue)
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-vita"])).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Playstation", func() {
+			Convey("It should return false", func() {
+				So(NewPlaystation(NewUAParser(testPlatforms["firefox"])).Match(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/platforms/webos.go
+++ b/platforms/webos.go
@@ -1,0 +1,30 @@
+package platforms
+
+type WebOS struct {
+	p Parser
+}
+
+var (
+	webOSName          = "WebOS"
+	webOSVersionRegexp = []string{`OS\/?([\d.]+)`}
+	webOSRegex         = []string{`(?i)WebOS|hpwOS`}
+)
+
+func NewWebOS(p Parser) *WebOS {
+	return &WebOS{
+		p: p,
+	}
+}
+
+func (k *WebOS) Name() string {
+	return webOSName
+}
+
+// Version returns version for WebOS
+func (k *WebOS) Version() string {
+	return k.p.Version(webOSVersionRegexp, 1, "")
+}
+
+func (k *WebOS) Match() bool {
+	return k.p.Match(webOSRegex)
+}

--- a/platforms/webos_test.go
+++ b/platforms/webos_test.go
@@ -1,0 +1,57 @@
+package platforms
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewWebOS(t *testing.T) {
+	Convey("Subject: #NewWebOS", t, func() {
+		Convey("It should return a new WebOS instance", func() {
+			So(NewWebOS(NewUAParser("")), ShouldHaveSameTypeAs, &WebOS{})
+		})
+	})
+}
+
+func TestWebOSName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return WebOS", func() {
+			So(NewWebOS(NewUAParser("")).Name(), ShouldEqual, "WebOS")
+		})
+	})
+}
+
+func TestWebOSVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It should return the version", func() {
+				So(NewWebOS(NewUAParser(testPlatforms["webos"])).Version(), ShouldEqual, "4.1.0")
+				So(NewWebOS(NewUAParser(testPlatforms["webos-hp"])).Version(), ShouldEqual, "3.0.5")
+			})
+		})
+
+		Convey("When the version is not matched", func() {
+			Convey("It should return default version", func() {
+				So(NewWebOS(NewUAParser(testPlatforms["firefox"])).Version(), ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func TestWebOSMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches WebOS", func() {
+			Convey("It should return true", func() {
+				So(NewWebOS(NewUAParser(testPlatforms["webos"])).Match(), ShouldBeTrue)
+				So(NewWebOS(NewUAParser(testPlatforms["webos-hp"])).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match WebOS", func() {
+			Convey("It should return false", func() {
+				So(NewWebOS(NewUAParser(testPlatforms["firefox"])).Match(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/platforms/windows_phone_test.go
+++ b/platforms/windows_phone_test.go
@@ -26,7 +26,7 @@ func TestWindowsPhoneVersion(t *testing.T) {
 	Convey("Subject: #Version", t, func() {
 		Convey("When the version is matched", func() {
 			Convey("It should return the version", func() {
-				wp := NewWindowsPhone(NewUAParser(testPlatforms["windows-phone"]))
+				wp := NewWindowsPhone(NewUAParser(testPlatforms["windows-phone-1"]))
 				So(wp.Version(), ShouldEqual, "10.0")
 			})
 		})
@@ -44,7 +44,8 @@ func TestWindowsPhoneMatch(t *testing.T) {
 	Convey("Subject: #Match", t, func() {
 		Convey("When user agent matches Windows Phone", func() {
 			Convey("It should return true", func() {
-				So(NewWindowsPhone(NewUAParser(testPlatforms["windows-phone"])).Match(), ShouldBeTrue)
+				So(NewWindowsPhone(NewUAParser(testPlatforms["windows-phone-1"])).Match(), ShouldBeTrue)
+				So(NewWindowsPhone(NewUAParser(testPlatforms["windows-phone-2"])).Match(), ShouldBeTrue)
 			})
 		})
 

--- a/platforms/xbox.go
+++ b/platforms/xbox.go
@@ -1,0 +1,29 @@
+package platforms
+
+type Xbox struct {
+	p Parser
+}
+
+var (
+	xboxName       = "Xbox"
+	xboxMatchRegex = []string{`Xbox`}
+)
+
+func NewXbox(p Parser) *Xbox {
+	return &Xbox{
+		p: p,
+	}
+}
+
+func (k *Xbox) Name() string {
+	return xboxName
+}
+
+// Version returns empty string for Xbox
+func (k *Xbox) Version() string {
+	return ""
+}
+
+func (k *Xbox) Match() bool {
+	return k.p.Match(xboxMatchRegex)
+}

--- a/platforms/xbox_test.go
+++ b/platforms/xbox_test.go
@@ -1,0 +1,55 @@
+package platforms
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewXbox(t *testing.T) {
+	Convey("Subject: #NewXbox", t, func() {
+		Convey("It should return a new Xbox instance", func() {
+			So(NewXbox(NewUAParser("")), ShouldHaveSameTypeAs, &Xbox{})
+		})
+	})
+}
+
+func TestXboxName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Xbox", func() {
+			So(NewXbox(NewUAParser("")).Name(), ShouldEqual, "Xbox")
+		})
+	})
+}
+
+func TestXboxVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It does not detect version", func() {
+				So(NewXbox(NewUAParser(testPlatforms["xbox"])).Version(), ShouldEqual, "")
+			})
+		})
+
+		Convey("When is not Xbox", func() {
+			Convey("It should return default version", func() {
+				So(NewXbox(NewUAParser(testPlatforms["firefox"])).Version(), ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func TestXboxMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Xbox", func() {
+			Convey("It should return true", func() {
+				So(NewXbox(NewUAParser(testPlatforms["xbox"])).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Xbox", func() {
+			Convey("It should return false", func() {
+				So(NewXbox(NewUAParser(testPlatforms["firefox"])).Match(), ShouldBeFalse)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Added the following browsers:

- [Amazon Silk](https://docs.aws.amazon.com/silk/)
- Baidu
- [Coc Coc](https://coccoc.com/en/)
- [Android Browser](https://developer.chrome.com/multidevice/webview/overview)
- Nintendo Browser

Added detection for following platforms:
- PlayStation
- Kindle
- Nintendo
- XBox
- [WebOS](https://www.lg.com/us/webos)
- MacOS

Extended TV device detection

Fixed iPad detection for Aloha Browser
Fixed Windows Phone detection for Lumia