### PR TITLE
Add support for Coc Coc browser detection

### DIFF
--- a/assets/test/matchers.yml
+++ b/assets/test/matchers.yml
@@ -20,6 +20,10 @@ chrome:
   linux: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36
   mac: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.155 Safari/537.36
   windows: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.155 Safari/537.36
+coc-coc:
+  android: Mozilla/5.0 (Linux; Android 9.0.99; MYNETTV-2H) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/80.0.232 Chrome/74.0.3729.232 Safari/537.36
+  mac: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/94.0.210 Chrome/88.0.4324.210 Safari/537.36
+  windows: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/56.3.162 Chrome/50.3.2661.162 Safari/537.36
 duck_duck_go:
   android: Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.132 Mobile Safari/537.36 DuckDuckGo/5
   ios: DuckDuckGo/2 CFNetwork/897.15 Darwin/17.5.0

--- a/browser.go
+++ b/browser.go
@@ -93,6 +93,7 @@ func (b *Browser) register() {
 		matchers.NewInternetExplorer(parser),
 		matchers.NewSamsungBrowser(parser),
 		matchers.NewSilkBrowser(parser),
+		matchers.NewCocCoc(parser),
 		matchers.NewSogouBrowser(parser),
 		matchers.NewVivaldi(parser),
 		matchers.NewVivoBrowser(parser),
@@ -441,6 +442,17 @@ func (b *Browser) IsSamsungBrowser() bool {
 // https://docs.aws.amazon.com/silk/
 func (b *Browser) IsSilkBrowser() bool {
 	if _, ok := b.getMatcher().(*matchers.SilkBrowser); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsCocCoc returns true if the browser is Coc Coc.
+//
+// https://coccoc.com/en/
+func (b *Browser) IsCocCoc() bool {
+	if _, ok := b.getMatcher().(*matchers.CocCoc); ok {
 		return true
 	}
 

--- a/browser_test.go
+++ b/browser_test.go
@@ -1046,3 +1046,23 @@ func TestBrowserIsVivaldi(t *testing.T) {
 		})
 	})
 }
+
+func TestBrowserIsCocCoc(t *testing.T) {
+	Convey("Subject: #IsCocCoc", t, func() {
+		Convey("When the browser is Coc Coc", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["coc-coc"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsCocCoc(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the browser is not CocCoc", func() {
+			Convey("It should return false", func() {
+				ua := testUserAgents["chrome"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsCocCoc(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/matchers/coc_coc.go
+++ b/matchers/coc_coc.go
@@ -1,0 +1,33 @@
+package matchers
+
+type CocCoc struct {
+	p Parser
+}
+
+var (
+	cocCocName         = "Coc Coc"
+	cocCocVersionRegex = []string{
+		`(?i)coc_coc_browser/([\d.]+)`,
+		`Chrome/([\d.]+)`,
+		`Safari/([\d.]+)`,
+	}
+	cocCocMatchRegex = []string{`coc_coc_browser/`}
+)
+
+func NewCocCoc(p Parser) *CocCoc {
+	return &CocCoc{
+		p: p,
+	}
+}
+
+func (s *CocCoc) Name() string {
+	return cocCocName
+}
+
+func (s *CocCoc) Version() string {
+	return s.p.Version(cocCocVersionRegex, 1)
+}
+
+func (s *CocCoc) Match() bool {
+	return s.p.Match(cocCocMatchRegex)
+}

--- a/matchers/coc_coc_test.go
+++ b/matchers/coc_coc_test.go
@@ -1,0 +1,66 @@
+package matchers
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewCocCoc(t *testing.T) {
+	Convey("Subject: #NewCocCoc", t, func() {
+		Convey("It should return a new CocCoc instance", func() {
+			So(NewCocCoc(NewUAParser("")), ShouldHaveSameTypeAs, &CocCoc{})
+		})
+	})
+}
+
+func TestCocCocName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Coc Coc", func() {
+			sb := NewCocCoc(NewUAParser(""))
+			So(sb.Name(), ShouldEqual, "Coc Coc")
+		})
+	})
+}
+
+func TestCocCocVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It should return the version", func() {
+				sb := testUserAgents["coc-coc"]
+
+				So(NewCocCoc(NewUAParser(sb.Android)).Version(), ShouldEqual, "80.0.232")
+				So(NewCocCoc(NewUAParser(sb.Mac)).Version(), ShouldEqual, "94.0.210")
+				So(NewCocCoc(NewUAParser(sb.Windows)).Version(), ShouldEqual, "56.3.162")
+			})
+		})
+
+		Convey("When the version is not matched", func() {
+			Convey("It should return default version", func() {
+				sb := NewCocCoc(NewUAParser("Mozilla/5.0 (Linux; Android 4.4.2; SM-G900F Build/KOT49H)"))
+				So(sb.Version(), ShouldEqual, "0.0")
+			})
+		})
+	})
+}
+
+func TestCocCocMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Coc Coc", func() {
+			Convey("It should return true", func() {
+				sb := testUserAgents["coc-coc"]
+
+				So(NewCocCoc(NewUAParser(sb.Android)).Match(), ShouldBeTrue)
+				So(NewCocCoc(NewUAParser(sb.Mac)).Match(), ShouldBeTrue)
+				So(NewCocCoc(NewUAParser(sb.Windows)).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Silk Browser", func() {
+			Convey("It should return false", func() {
+				sb := NewCocCoc(NewUAParser(testUserAgents["chrome"].Android))
+				So(sb.Match(), ShouldBeFalse)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Implemented a new matcher to identify the Coc Coc browser, including its version parsing and user agent matching. Added corresponding test cases to ensure accurate detection and functionality. Updated test assets with sample user agents for Coc Coc across multiple platforms.