### PR TITLE
Add support for Android Browser detection

### DIFF
--- a/assets/test/matchers.yml
+++ b/assets/test/matchers.yml
@@ -4,6 +4,8 @@ alipay:
   ios: Mozilla/5.0 (iPhone; CPU iPhone OS 9_3 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E230 ChannelId(3) Nebula PSDType(1) AlipayDefined(nt:WIFI,ws:320|504|2.0) AliApp(AP/9.9.0.000001) AlipayClient/9.9.0.000001 Language/zh-Hans ProductType/dev
   mac: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2,AlipayClient) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.134 Safari/537.36
   windows: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/538.1 (KHTML like Gecko) alipay_demo1 Safari/538.1
+android-browser:
+  android: Mozilla/5.0     (Linux; U) AppleWebKit/537.36 (KHTML, like Gecko)     Version/4.0 Mobile Safari/537.36 SmartTV/7.0 (NetCast) Android
 blackberry:
   android: Mozilla/5.0 (Linux; Android 7.1.1; BBB100-3 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   ios: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 ZONApp/iOS/1.8.1 bb105a49-62d6-4895-b831-6c1da9c92e6e

--- a/browser.go
+++ b/browser.go
@@ -101,6 +101,7 @@ func (b *Browser) register() {
 		matchers.NewYaaniBrowser(parser),
 		matchers.NewYandex(parser),
 		matchers.NewFirefox(parser),
+		matchers.NewAndroidBrowser(parser),
 		matchers.NewChrome(parser), // chrome should be before safari
 		matchers.NewSafari(parser), // chrome and safari must be at the end
 		matchers.NewUnknown(parser),
@@ -164,6 +165,19 @@ func (b *Browser) Device() *Device {
 // Bot returns the bot of the browser.
 func (b *Browser) Bot() *Bot {
 	return b.bot
+}
+
+// IsAndroidBrowser returns true if the browser is Android Browser
+//
+// Android WebView on Android >= 4.4 is purposefully being identified as Chrome
+//
+// https://developer.chrome.com/multidevice/webview/overview
+func (b *Browser) IsAndroidBrowser() bool {
+	if _, ok := b.getMatcher().(*matchers.AndroidBrowser); ok {
+		return true
+	}
+
+	return false
 }
 
 // IsAliPay returns true if the browser is AliPay.

--- a/browser_test.go
+++ b/browser_test.go
@@ -317,6 +317,26 @@ func TestBrowserIsAlipay(t *testing.T) {
 	})
 }
 
+func TestBrowserIsAndroidBrowser(t *testing.T) {
+	Convey("Subject: #IsAndroidBrowser", t, func() {
+		Convey("When the browser is Android Browser", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["android-browser"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsAndroidBrowser(), ShouldBeTrue)
+			})
+
+			Convey("When the browser is not Android Browser", func() {
+				Convey("It should return false", func() {
+					ua := testUserAgents["chrome"]
+					b, _ := NewBrowser(ua.Android)
+					So(b.IsAndroidBrowser(), ShouldBeFalse)
+				})
+			})
+		})
+	})
+}
+
 func TestBrowserIsNokia(t *testing.T) {
 	Convey("Subject: #IsNokia", t, func() {
 		Convey("When the browser is Nokia", func() {

--- a/matchers/android_browser.go
+++ b/matchers/android_browser.go
@@ -1,0 +1,33 @@
+package matchers
+
+import "strings"
+
+type AndroidBrowser struct {
+	p Parser
+}
+
+var (
+	androidBrowserName          = "Android Browser"
+	androidBrowserVersionRegexp = []string{`Version/([\d.]+)`}
+)
+
+func NewAndroidBrowser(p Parser) *AndroidBrowser {
+	return &AndroidBrowser{
+		p: p,
+	}
+}
+
+func (b *AndroidBrowser) Name() string {
+	return androidBrowserName
+}
+
+func (b *AndroidBrowser) Version() string {
+	return b.p.Version(androidBrowserVersionRegexp, 1)
+}
+
+func (b *AndroidBrowser) Match() bool {
+	// Without lookbehinds in Go regexp library, it is much easier to use strings.Contains
+	ua := strings.ToLower(b.p.String())
+
+	return strings.Contains(ua, "android") && !strings.Contains(ua, "chrome/") && strings.Contains(ua, "version/") && !strings.Contains(ua, "like android")
+}

--- a/matchers/android_browser_test.go
+++ b/matchers/android_browser_test.go
@@ -1,0 +1,62 @@
+package matchers
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewAndroidBrowser(t *testing.T) {
+	Convey("Subject: #NewAndroidBrowser", t, func() {
+		Convey("It should return a new Android Browser instance", func() {
+			So(NewAndroidBrowser(NewUAParser("")), ShouldHaveSameTypeAs, &AndroidBrowser{})
+		})
+	})
+}
+
+func TestAndroidBrowserName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return AndroidBrowser", func() {
+			sb := NewAndroidBrowser(NewUAParser(""))
+			So(sb.Name(), ShouldEqual, "Android Browser")
+		})
+	})
+}
+
+func TestAndroidBrowserVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It should return the version", func() {
+				sb := testUserAgents["android-browser"]
+
+				So(NewAndroidBrowser(NewUAParser(sb.Android)).Version(), ShouldEqual, "4.0")
+			})
+		})
+
+		Convey("When the version is not matched", func() {
+			Convey("It should return default version", func() {
+				sb := NewAndroidBrowser(NewUAParser("Mozilla/5.0 (Linux; Android 4.4.2; SM-G900F Build/KOT49H)"))
+				So(sb.Version(), ShouldEqual, "0.0")
+			})
+		})
+	})
+}
+
+func TestAndroidBrowserMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Android Browser", func() {
+			Convey("It should return true", func() {
+				sb := testUserAgents["android-browser"]
+
+				So(NewAndroidBrowser(NewUAParser(sb.Android)).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Android Browser", func() {
+			Convey("It should return false", func() {
+				sb := NewAndroidBrowser(NewUAParser(testUserAgents["chrome"].Android))
+				So(sb.Match(), ShouldBeFalse)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Introduce a new matcher for identifying Android Browser, including its versioning logic. Added relevant tests and updated test assets to ensure accurate detection and compatibility.