### PR TITLE
Add Nintendo browser matcher support

### DIFF
--- a/assets/test/matchers.yml
+++ b/assets/test/matchers.yml
@@ -86,6 +86,8 @@ miui-browser:
   ios: Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10 XiaoMi/Mi-Pad/MiuiBrowser/1.0
   linux: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.34 Safari/534.24 XiaoMi/MiuiBrowser/2.0.1
   windows: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/71.0.3578.141 Safari/534.24 XiaoMi/MiuiBrowser/12.5.2-gn
+nintendo:
+  linux: Mozilla/5.0 (Nintendo Switch; WifiWebAuthApplet) AppleWebKit/609.4 (KHTML, like Gecko) NF/6.0.2.26.0 NintendoBrowser/5.1.0.23653
 nokia:
   android: Mozilla/5.0 (Linux; Android 4.1.2; Nokia_X Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36 NokiaBrowser/1.2.0.12
   linux: Mozilla/5.0 (Series40; Nokia302/14.53; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/2.3.0.0.48

--- a/browser.go
+++ b/browser.go
@@ -70,6 +70,7 @@ func (b *Browser) register() {
 	matchers := []BrowserMatcher{
 		matchers.NewAlipay(parser),
 		matchers.NewNokia(parser),
+		matchers.NewNintendo(parser),
 		matchers.NewUCBrowser(parser),
 		matchers.NewBlackBerry(parser),
 		matchers.NewBrave(parser),
@@ -185,6 +186,15 @@ func (b *Browser) IsAndroidBrowser() bool {
 // https://www.alipay.com/
 func (b *Browser) IsAlipay() bool {
 	if _, ok := b.getMatcher().(*matchers.Alipay); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsNintendo returns true if the browser is Nintendo.
+func (b *Browser) IsNintendo() bool {
+	if _, ok := b.getMatcher().(*matchers.Nintendo); ok {
 		return true
 	}
 

--- a/browser_test.go
+++ b/browser_test.go
@@ -357,6 +357,26 @@ func TestBrowserIsNokia(t *testing.T) {
 	})
 }
 
+func TestBrowserIsNintendo(t *testing.T) {
+	Convey("Subject: #IsNintendo", t, func() {
+		Convey("When the browser is Nintendo", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["nintendo"]
+				b, _ := NewBrowser(ua.Linux)
+				So(b.IsNintendo(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the browser is not Nintendo", func() {
+			Convey("It should return false", func() {
+				ua := testUserAgents["chrome"]
+				b, _ := NewBrowser(ua.Linux)
+				So(b.IsNintendo(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
 func TestBrowserIsUCBrowser(t *testing.T) {
 	Convey("Subject: #IsUCBrowser", t, func() {
 		Convey("When the browser is UC Browser", func() {

--- a/matchers/nintendo.go
+++ b/matchers/nintendo.go
@@ -1,0 +1,29 @@
+package matchers
+
+type Nintendo struct {
+	p Parser
+}
+
+var (
+	nintendoName          = "Nintendo"
+	nintendoVersionRegexp = []string{`NintendoBrowser/([\d.]+)`}
+	nintendoMatchRegexp   = []string{`NintendoBrowser`}
+)
+
+func NewNintendo(p Parser) *Nintendo {
+	return &Nintendo{
+		p: p,
+	}
+}
+
+func (n *Nintendo) Name() string {
+	return nintendoName
+}
+
+func (n *Nintendo) Version() string {
+	return n.p.Version(nintendoVersionRegexp, 1)
+}
+
+func (n *Nintendo) Match() bool {
+	return n.p.Match(nintendoMatchRegexp)
+}

--- a/matchers/nintendo_test.go
+++ b/matchers/nintendo_test.go
@@ -1,0 +1,62 @@
+package matchers
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewNintendo(t *testing.T) {
+	Convey("Subject: #NewNintendo", t, func() {
+		Convey("It should return a new Nintendo instance", func() {
+			So(NewNintendo(NewUAParser("")), ShouldHaveSameTypeAs, &Nintendo{})
+		})
+	})
+}
+
+func TestNintendoName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Nintendo", func() {
+			n := NewNintendo(NewUAParser(""))
+			So(n.Name(), ShouldEqual, "Nintendo")
+		})
+	})
+}
+
+func TestNintendoVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		ua := testUserAgents["nintendo"]
+		Convey("When the version is matched", func() {
+			Convey("It should return the version", func() {
+				So(NewNintendo(NewUAParser(ua.Linux)).Version(), ShouldEqual, "5.1.0.23653")
+			})
+		})
+	})
+
+	Convey("When the version is not matched", t, func() {
+		Convey("It should return default version", func() {
+			n := NewNintendo(NewUAParser(testUserAgents["chrome"].Linux))
+			So(n.Version(), ShouldEqual, "0.0")
+		})
+	})
+}
+
+func TestNintendoMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Nintendo", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["nintendo"]
+
+				So(NewNintendo(NewUAParser(ua.Linux)).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Nintendo", func() {
+			Convey("It should return false", func() {
+				ua := testUserAgents["chrome"]
+
+				So(NewNintendo(NewUAParser(ua.Linux)).Match(), ShouldBeFalse)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Implemented a new matcher for identifying the Nintendo browser, including its name, version, and user agent matching functionality. Updated the browser logic to incorporate the Nintendo matcher and added corresponding tests to ensure proper functionality. Also updated test configurations with representative Nintendo user agent data.