### PR TITLE
Add support for detecting PlayStation platforms

### DIFF
--- a/assets/test/platforms.yml
+++ b/assets/test/platforms.yml
@@ -71,6 +71,11 @@ linux: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) At
 mac-os: XMind/10.2.1.202007271856 (darwin.x64; macOS Arch/x64 Version/11.0.1; en-US) Electron/5.0.13
 mac-os-1: MOZILLA/5.0 (MACINTOSH; INTEL MAC OS X 10_14_6) APPLEWEBKIT/537.36 (KHTML LIKE GECKO) CHROME/94.0.4606.61 SAFARI/537.36
 mac-os-x: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11) AppleWebKit/537.36 (KHTML, like Gecko) NativefierPlaceholder/0.0.1 Chrome/47.0.2526.73 Electron/0.36.4 Safari/537.36
+playstation-3: Mozilla/5.0 (PLAYSTATION 3 4.91) AppleWebKit/531.22.8 (KHTML, like Gecko)
+playstation-4: Mozilla/5.0 (PlayStation; PlayStation 4/12.00) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15
+playstation-5: Mozilla/5.0 (PlayStation; PlayStation 5/10.40; PlayStation 4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15
+playstation-smarttv: Mozilla/5.0 (PlayStation 5/SmartTV) AppleWebKit/605.1.15 (KHTML, like Gecko)
+playstation-vita: Mozilla/5.0 (PlayStation Vita 3.74) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2
 windows-10: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Atom/1.6.2 Chrome/45.0.2454.85 Electron/0.34.5 Safari/537.36
 windows-7: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0; Wildfire NoTrail; ProE-Datecode:3302014090)
 windows-8: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) your-app/0.1.0 Chrome/41.0.2272.76 Electron/0.24.0 Safari/537.36

--- a/platform.go
+++ b/platform.go
@@ -57,6 +57,7 @@ func (p *Platform) register() {
 		platforms.NewLinux(parser),
 		platforms.NewFirefoxOS(parser),
 		platforms.NewChromeOS(parser),
+		platforms.NewPlaystation(parser),
 		platforms.NewUnknown(parser),
 	}
 
@@ -168,6 +169,15 @@ func (p *Platform) IsLinux() bool {
 // IsBlackBerry returns true if platform is BlackBerry.
 func (p *Platform) IsBlackBerry() bool {
 	if _, ok := p.getMatcher().(*platforms.BlackBerry); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsPlaystation returns true if platform is PlayStation
+func (p *Platform) IsPlaystation() bool {
+	if _, ok := p.getMatcher().(*platforms.Playstation); ok {
 		return true
 	}
 

--- a/platform_test.go
+++ b/platform_test.go
@@ -273,6 +273,27 @@ func TestPlatformIsBlackberry(t *testing.T) {
 	})
 }
 
+func TestPlatformIsPlaystation(t *testing.T) {
+	Convey("Given a user agent string", t, func() {
+		Convey("When the platform is Playstation", func() {
+			Convey("It returns true", func() {
+				platforms := []string{"playstation-3", "playstation-4", "playstation-5", "playstation-vita"}
+				for _, platform := range platforms {
+					p, _ := NewPlatform(testPlatforms[platform])
+					So(p.IsPlaystation(), ShouldBeTrue)
+				}
+			})
+		})
+
+		Convey("When the platform is not Playstation", func() {
+			p, _ := NewPlatform(testPlatforms["linux"])
+			Convey("It returns false", func() {
+				So(p.IsPlaystation(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
 func TestPlatformIsWindowsMobile(t *testing.T) {
 	Convey("Given a user agent string", t, func() {
 		Convey("When the platform is Windows Mobile", func() {

--- a/platforms/playstation.go
+++ b/platforms/playstation.go
@@ -1,0 +1,33 @@
+package platforms
+
+type Playstation struct {
+	p Parser
+}
+
+var (
+	playstationOSName          = "Playstation"
+	playstationOSVersionRegexp = []string{`(?i)playstation(\s*(\d+|vita))?[ \/]?([\d.]+)`}
+	playstationOSMatchRegexp   = []string{`(?i)playstation`}
+)
+
+func NewPlaystation(p Parser) *Playstation {
+	return &Playstation{
+		p: p,
+	}
+}
+
+func (w *Playstation) Name() string {
+	return playstationOSName
+}
+
+func (w *Playstation) Version() string {
+	globalVersion := w.p.Version(playstationOSVersionRegexp, 1, "0.0")
+	if globalVersion == "0.0" || globalVersion == "" {
+		return "0.0"
+	}
+	return w.p.Version(playstationOSVersionRegexp, 3, "0.0")
+}
+
+func (w *Playstation) Match() bool {
+	return w.p.Match(playstationOSMatchRegexp)
+}

--- a/platforms/playstation_test.go
+++ b/platforms/playstation_test.go
@@ -1,0 +1,64 @@
+package platforms
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewPlaystation(t *testing.T) {
+	Convey("Subject: #NewPlaystation", t, func() {
+		Convey("It should return a new Playstation instance", func() {
+			So(NewPlaystation(NewUAParser("")), ShouldHaveSameTypeAs, &Playstation{})
+		})
+	})
+}
+
+func TestPlaystationName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Playstation", func() {
+			So(NewPlaystation(NewUAParser(testPlatforms["playstation-3"])).Name(), ShouldEqual, "Playstation")
+			So(NewPlaystation(NewUAParser(testPlatforms["playstation-4"])).Name(), ShouldEqual, "Playstation")
+			So(NewPlaystation(NewUAParser(testPlatforms["playstation-vita"])).Name(), ShouldEqual, "Playstation")
+		})
+	})
+}
+
+func TestPlaystationVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It should return the version", func() {
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-3"])).Version(), ShouldEqual, "4.91")
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-4"])).Version(), ShouldEqual, "12.00")
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-5"])).Version(), ShouldEqual, "10.40")
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-vita"])).Version(), ShouldEqual, "3.74")
+			})
+		})
+
+		Convey("When the version is not matched", func() {
+			Convey("It should return default version", func() {
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-smarttv"])).Version(), ShouldEqual, "0.0")
+			})
+		})
+	})
+}
+
+func TestPlaystationMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Playstation", func() {
+			Convey("It should return true", func() {
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-3"])).Match(), ShouldBeTrue)
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-4"])).Match(), ShouldBeTrue)
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-5"])).Match(), ShouldBeTrue)
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-smarttv"])).Match(), ShouldBeTrue)
+				So(NewPlaystation(NewUAParser(testPlatforms["playstation-vita"])).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Playstation", func() {
+			Convey("It should return false", func() {
+				So(NewPlaystation(NewUAParser(testPlatforms["firefox"])).Match(), ShouldBeFalse)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Introduced a new PlayStation platform matcher with corresponding functionality to detect name, version, and user-agent match. Added tests to validate PlayStation platform identification and integrated test data into the platform test suite.