### PR TITLE
Add Baidu browser detection and support

### DIFF
--- a/assets/test/matchers.yml
+++ b/assets/test/matchers.yml
@@ -6,6 +6,9 @@ alipay:
   windows: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/538.1 (KHTML like Gecko) alipay_demo1 Safari/538.1
 android-browser:
   android: Mozilla/5.0     (Linux; U) AppleWebKit/537.36 (KHTML, like Gecko)     Version/4.0 Mobile Safari/537.36 SmartTV/7.0 (NetCast) Android
+baidu:
+  android: Mozilla/5.0 (Linux; Android 10; HLK-AL00 Build/HONORHLK-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/97.0.4692.98 Mobile Safari/537.36 T7/13.81 BDOS/1.0 (HarmonyOS 2.2.0) SP-engine/3.22.0 baiduboxapp/13.81.1.10 (Baidu; P1 10) NABar/1.0
+  ios: Mozilla/5.0 (iPhone; CPU iPhone OS 18_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 SP-engine/3.22.0 main/1.0 baiduboxapp/13.81.1.10 (Baidu; P2 18.1.1) NABar/1.0 themeUA=Theme/default
 blackberry:
   android: Mozilla/5.0 (Linux; Android 7.1.1; BBB100-3 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   ios: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 ZONApp/iOS/1.8.1 bb105a49-62d6-4895-b831-6c1da9c92e6e

--- a/browser.go
+++ b/browser.go
@@ -72,6 +72,7 @@ func (b *Browser) register() {
 		matchers.NewNokia(parser),
 		matchers.NewNintendo(parser),
 		matchers.NewUCBrowser(parser),
+		matchers.NewBaidu(parser),
 		matchers.NewBlackBerry(parser),
 		matchers.NewBrave(parser),
 		matchers.NewOpera(parser),
@@ -186,6 +187,17 @@ func (b *Browser) IsAndroidBrowser() bool {
 // https://www.alipay.com/
 func (b *Browser) IsAlipay() bool {
 	if _, ok := b.getMatcher().(*matchers.Alipay); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsBaidu returns true if the browser is Baidu.
+//
+// http://liulanqi.baidu.com/
+func (b *Browser) IsBaidu() bool {
+	if _, ok := b.getMatcher().(*matchers.Baidu); ok {
 		return true
 	}
 

--- a/browser_test.go
+++ b/browser_test.go
@@ -337,6 +337,26 @@ func TestBrowserIsAndroidBrowser(t *testing.T) {
 	})
 }
 
+func TestBrowserIsBaidu(t *testing.T) {
+	Convey("Subject: #IsBaidu", t, func() {
+		Convey("When the browser is Baidu", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["baidu"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsBaidu(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the browser is not Baidu", func() {
+			Convey("It should return false", func() {
+				ua := testUserAgents["chrome"]
+				b, _ := NewBrowser(ua.Android)
+				So(b.IsBaidu(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
 func TestBrowserIsNokia(t *testing.T) {
 	Convey("Subject: #IsNokia", t, func() {
 		Convey("When the browser is Nokia", func() {

--- a/matchers/baidu.go
+++ b/matchers/baidu.go
@@ -1,0 +1,29 @@
+package matchers
+
+type Baidu struct {
+	p Parser
+}
+
+var (
+	baiduName          = "Baidu"
+	baiduVersionRegexp = []string{`baiduboxapp/([\d.]+)`}
+	baiduMatchRegex    = []string{`(?i)baiduboxapp`}
+)
+
+func NewBaidu(p Parser) *Baidu {
+	return &Baidu{
+		p: p,
+	}
+}
+
+func (a *Baidu) Name() string {
+	return baiduName
+}
+
+func (a *Baidu) Version() string {
+	return a.p.Version(baiduVersionRegexp, 1)
+}
+
+func (a *Baidu) Match() bool {
+	return a.p.Match(baiduMatchRegex)
+}

--- a/matchers/baidu_test.go
+++ b/matchers/baidu_test.go
@@ -1,0 +1,59 @@
+package matchers
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewBaidu(t *testing.T) {
+	Convey("Subject: #NewBaidu", t, func() {
+		Convey("It should return a new Baidu instance", func() {
+			baidu := NewBaidu(NewUAParser(""))
+			So(baidu, ShouldHaveSameTypeAs, &Baidu{})
+		})
+	})
+}
+
+func TestBaiduName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return the correct name", func() {
+			baidu := NewBaidu(NewUAParser(""))
+			So(baidu.Name(), ShouldEqual, "Baidu")
+		})
+	})
+}
+
+func TestBaiduVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is captured", func() {
+			Convey("It should return the version", func() {
+				ua := testUserAgents["baidu"]
+
+				So(NewBaidu(NewUAParser(ua.IOS)).Version(), ShouldEqual, "13.81.1.10")
+				So(NewBaidu(NewUAParser(ua.Android)).Version(), ShouldEqual, "13.81.1.10")
+			})
+		})
+
+	})
+}
+
+func TestBaiduMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Baidu", func() {
+			Convey("It should return true", func() {
+				ua := testUserAgents["baidu"]
+				So(NewBaidu(NewUAParser(ua.IOS)).Match(), ShouldBeTrue)
+				So(NewBaidu(NewUAParser(ua.Android)).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Baidu", func() {
+			Convey("It should return false", func() {
+				ua := "Mozilla/5.0 (Linux; Android 10; Redmi K30 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.101 Mobile Safari/537.36"
+				baidu := NewBaidu(NewUAParser(ua))
+				So(baidu.Match(), ShouldBeFalse)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Introduce functionality to detect the Baidu browser by implementing a new matcher and corresponding methods in the `Browser` struct. Includes tests to ensure proper identification and handling of Baidu browser user agents. Updated test assets with Baidu-specific user agent strings.