### PR TITLE
Add support for detecting Kindle platform

### DIFF
--- a/assets/test/platforms.yml
+++ b/assets/test/platforms.yml
@@ -67,6 +67,7 @@ ios-8: Mozilla/5.0 (iPhone; CPU iPhone OS 8_7_2; like Mac OS X) AppleWebKit/535.
 ios-app: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B93 Electron/like MathspaceIOS/2.7.2
 kai-os-1: Mozilla/5.0 (Mobile; ALCATEL4044T; rv:37.0) Gecko/37.0 Firefox/37.0 KaiOS/1.0
 kai-os-2: Mozilla/5.0 (Mobile; LYF/LF-2403N/LYF-LF2403N-000-01-18IMEI-040817-i; rv:48.0) Gecko/48.0 Firefox/48.0 KaiOS/2.0
+kindle: Mozilla/5.0 (Linux; U; Android 4.4; en-US; Amazon Kindle Fire HD Build/KRT16S) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.10.1227 Mobile Safari/537.36
 linux: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Atom/1.0.15 Chrome/43.0.2357.65 Electron/0.30.6 Safari/537.36
 mac-os: XMind/10.2.1.202007271856 (darwin.x64; macOS Arch/x64 Version/11.0.1; en-US) Electron/5.0.13
 mac-os-1: MOZILLA/5.0 (MACINTOSH; INTEL MAC OS X 10_14_6) APPLEWEBKIT/537.36 (KHTML LIKE GECKO) CHROME/94.0.4606.61 SAFARI/537.36

--- a/platform.go
+++ b/platform.go
@@ -53,6 +53,7 @@ func (p *Platform) register() {
 		platforms.NewWindowsMobile(parser),
 		platforms.NewWindowsPhone(parser),
 		platforms.NewWindows(parser),
+		platforms.NewKindle(parser), // Should come before Android
 		platforms.NewAndroid(parser),
 		platforms.NewLinux(parser),
 		platforms.NewFirefoxOS(parser),
@@ -151,6 +152,15 @@ func (p *Platform) IsWatchOS() bool {
 // IsKaiOS returns true if the user agent string matches KaiOS.
 func (p *Platform) IsKaiOS() bool {
 	if _, ok := p.getMatcher().(*platforms.KaiOS); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsKindle returns true if the user agent string matches Kindle.
+func (p *Platform) IsKindle() bool {
+	if _, ok := p.getMatcher().(*platforms.Kindle); ok {
 		return true
 	}
 

--- a/platform_test.go
+++ b/platform_test.go
@@ -237,6 +237,24 @@ func TestPlatformIsKaiOS(t *testing.T) {
 	})
 }
 
+func TestPlatformIsKindle(t *testing.T) {
+	Convey("Given a user agent string", t, func() {
+		Convey("When the platform is Kindle", func() {
+			p, _ := NewPlatform(testPlatforms["kindle"])
+			Convey("It returns true", func() {
+				So(p.IsKindle(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the platform is not Kindle", func() {
+			p, _ := NewPlatform(testPlatforms["blackberry"])
+			Convey("It returns false", func() {
+				So(p.IsKindle(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
 func TestPlatformIsLinux(t *testing.T) {
 	Convey("Given a user agent string", t, func() {
 		Convey("When the platform is Linux", func() {

--- a/platforms/kindle.go
+++ b/platforms/kindle.go
@@ -1,0 +1,29 @@
+package platforms
+
+type Kindle struct {
+	p Parser
+}
+
+var (
+	kindleName       = "Kindle"
+	kindleMatchRegex = []string{`Kindle`}
+)
+
+func NewKindle(p Parser) *Kindle {
+	return &Kindle{
+		p: p,
+	}
+}
+
+func (k *Kindle) Name() string {
+	return kindleName
+}
+
+// Version returns empty string for Kindle
+func (k *Kindle) Version() string {
+	return ""
+}
+
+func (k *Kindle) Match() bool {
+	return k.p.Match(kindleMatchRegex)
+}

--- a/platforms/kindle_test.go
+++ b/platforms/kindle_test.go
@@ -1,0 +1,55 @@
+package platforms
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewKindle(t *testing.T) {
+	Convey("Subject: #NewKindle", t, func() {
+		Convey("It should return a new Kindle instance", func() {
+			So(NewKindle(NewUAParser("")), ShouldHaveSameTypeAs, &Kindle{})
+		})
+	})
+}
+
+func TestKindleName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Kindle", func() {
+			So(NewKindle(NewUAParser("")).Name(), ShouldEqual, "Kindle")
+		})
+	})
+}
+
+func TestKindleVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It does not detect version", func() {
+				So(NewKindle(NewUAParser(testPlatforms["kindle"])).Version(), ShouldEqual, "")
+			})
+		})
+
+		Convey("When is not Kindle", func() {
+			Convey("It should return default version", func() {
+				So(NewKindle(NewUAParser(testPlatforms["firefox"])).Version(), ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func TestKindleMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Kindle", func() {
+			Convey("It should return true", func() {
+				So(NewKindle(NewUAParser(testPlatforms["kindle"])).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Kindle", func() {
+			Convey("It should return false", func() {
+				So(NewKindle(NewUAParser(testPlatforms["firefox"])).Match(), ShouldBeFalse)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Introduced a new Kindle matcher to identify Kindle user agents. Updated related tests and platform configurations, ensuring accurate detection and compatibility. This addition improves platform coverage and parsing accuracy.