### PR TITLE
Add support for detecting Nintendo platform

### DIFF
--- a/assets/test/platforms.yml
+++ b/assets/test/platforms.yml
@@ -72,6 +72,7 @@ linux: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) At
 mac-os: XMind/10.2.1.202007271856 (darwin.x64; macOS Arch/x64 Version/11.0.1; en-US) Electron/5.0.13
 mac-os-1: MOZILLA/5.0 (MACINTOSH; INTEL MAC OS X 10_14_6) APPLEWEBKIT/537.36 (KHTML LIKE GECKO) CHROME/94.0.4606.61 SAFARI/537.36
 mac-os-x: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11) AppleWebKit/537.36 (KHTML, like Gecko) NativefierPlaceholder/0.0.1 Chrome/47.0.2526.73 Electron/0.36.4 Safari/537.36
+nintendo: Mozilla/5.0 (Nintendo Switch; WifiWebAuthApplet) AppleWebKit/609.4 (KHTML, like Gecko) NF/6.0.2.26.0 NintendoBrowser/5.1.0.23653
 playstation-3: Mozilla/5.0 (PLAYSTATION 3 4.91) AppleWebKit/531.22.8 (KHTML, like Gecko)
 playstation-4: Mozilla/5.0 (PlayStation; PlayStation 4/12.00) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15
 playstation-5: Mozilla/5.0 (PlayStation; PlayStation 5/10.40; PlayStation 4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15

--- a/platform.go
+++ b/platform.go
@@ -58,6 +58,7 @@ func (p *Platform) register() {
 		platforms.NewLinux(parser),
 		platforms.NewFirefoxOS(parser),
 		platforms.NewChromeOS(parser),
+		platforms.NewNintendo(parser),
 		platforms.NewPlaystation(parser),
 		platforms.NewUnknown(parser),
 	}
@@ -179,6 +180,15 @@ func (p *Platform) IsLinux() bool {
 // IsBlackBerry returns true if platform is BlackBerry.
 func (p *Platform) IsBlackBerry() bool {
 	if _, ok := p.getMatcher().(*platforms.BlackBerry); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsLinux returns true if the platform is Nintendo.
+func (p *Platform) IsNintendo() bool {
+	if _, ok := p.getMatcher().(*platforms.Nintendo); ok {
 		return true
 	}
 

--- a/platform_test.go
+++ b/platform_test.go
@@ -273,6 +273,24 @@ func TestPlatformIsLinux(t *testing.T) {
 	})
 }
 
+func TestPlatformIsNintendo(t *testing.T) {
+	Convey("Given a user agent string", t, func() {
+		Convey("When the platform is Nintendo", func() {
+			p, _ := NewPlatform(testPlatforms["nintendo"])
+			Convey("It returns true", func() {
+				So(p.IsNintendo(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the platform is not Nintendo", func() {
+			p, _ := NewPlatform(testPlatforms["linux"])
+			Convey("It returns false", func() {
+				So(p.IsNintendo(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
 func TestPlatformIsBlackberry(t *testing.T) {
 	Convey("Given a user agent string", t, func() {
 		Convey("When the platform is BlackBerry", func() {

--- a/platforms/nintendo.go
+++ b/platforms/nintendo.go
@@ -1,0 +1,29 @@
+package platforms
+
+type Nintendo struct {
+	p Parser
+}
+
+var (
+	nintendoName       = "Nintendo"
+	nintendoMatchRegex = []string{`Nintendo`}
+)
+
+func NewNintendo(p Parser) *Nintendo {
+	return &Nintendo{
+		p: p,
+	}
+}
+
+func (k *Nintendo) Name() string {
+	return nintendoName
+}
+
+// Version returns empty string for Nintendo
+func (k *Nintendo) Version() string {
+	return ""
+}
+
+func (k *Nintendo) Match() bool {
+	return k.p.Match(nintendoMatchRegex)
+}

--- a/platforms/nintendo_test.go
+++ b/platforms/nintendo_test.go
@@ -1,0 +1,55 @@
+package platforms
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewNintendo(t *testing.T) {
+	Convey("Subject: #NewNintendo", t, func() {
+		Convey("It should return a new Nintendo instance", func() {
+			So(NewNintendo(NewUAParser("")), ShouldHaveSameTypeAs, &Nintendo{})
+		})
+	})
+}
+
+func TestNintendoName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Nintendo", func() {
+			So(NewNintendo(NewUAParser("")).Name(), ShouldEqual, "Nintendo")
+		})
+	})
+}
+
+func TestNintendoVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It does not detect version", func() {
+				So(NewNintendo(NewUAParser(testPlatforms["nintendo"])).Version(), ShouldEqual, "")
+			})
+		})
+
+		Convey("When is not Nintendo", func() {
+			Convey("It should return default version", func() {
+				So(NewNintendo(NewUAParser(testPlatforms["firefox"])).Version(), ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func TestNintendoMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Nintendo", func() {
+			Convey("It should return true", func() {
+				So(NewNintendo(NewUAParser(testPlatforms["nintendo"])).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Nintendo", func() {
+			Convey("It should return false", func() {
+				So(NewNintendo(NewUAParser(testPlatforms["firefox"])).Match(), ShouldBeFalse)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Introduce a new `Nintendo` struct for platform identification, along with corresponding methods and tests. Updated user agent matching logic and test data to handle Nintendo-specific detection.