### PR TITLE
Add Xbox platform support

### DIFF
--- a/assets/test/platforms.yml
+++ b/assets/test/platforms.yml
@@ -89,3 +89,4 @@ windows-rt: Mozilla/5.0 (Windows NT 6.3; ARM; Trident/7.0; Touch; .NET4.0E; .NET
 windows-touch: Mozilla/5.0 (Windows NT 6.3; ARM; Trident/7.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0; rv:11.0) like Gecko
 windows-vista: Mozilla/5.0 (Windows NT 6.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) mtz_krunker/1.15.10 Chrome/78.0.3905.1 Electron/7.0.0 Safari/537.36
 windows-xp: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; Wildfire NoTrail; ProE-Datecode:2902011330),gzip(gfe) (via translate.google.com)
+xbox: Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.64

--- a/platform.go
+++ b/platform.go
@@ -52,6 +52,7 @@ func (p *Platform) register() {
 		platforms.NewWatchOS(parser),
 		platforms.NewWindowsMobile(parser),
 		platforms.NewWindowsPhone(parser),
+		platforms.NewXbox(parser), // Should come before Windows
 		platforms.NewWindows(parser),
 		platforms.NewKindle(parser), // Should come before Android
 		platforms.NewAndroid(parser),
@@ -351,5 +352,14 @@ func (p *Platform) IsWindowsTouchScreenDesktop() bool {
 	if p.IsWindows() && strings.Contains(p.userAgent, "Touch") {
 		return true
 	}
+	return false
+}
+
+// IsXbox returns true if the platform is Xbox.
+func (p *Platform) IsXbox() bool {
+	if _, ok := p.getMatcher().(*platforms.Xbox); ok {
+		return true
+	}
+
 	return false
 }

--- a/platform_test.go
+++ b/platform_test.go
@@ -634,3 +634,24 @@ func TestPlatformIsWindowsTouchScreenDesktop(t *testing.T) {
 		})
 	})
 }
+
+func TestPlatformIsXbox(t *testing.T) {
+	Convey("Given a user agent string", t, func() {
+		Convey("When the platform is Xbox", func() {
+			p, _ := NewPlatform(testPlatforms["xbox"])
+			Convey("It returns true", func() {
+				So(p.IsXbox(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When the platform is not Xbox", func() {
+			Convey("It returns false", func() {
+				platforms := []string{"windows-10", "windows-8", "windows-7", "windows-xp"}
+				for _, platform := range platforms {
+					p, _ := NewPlatform(testPlatforms[platform])
+					So(p.IsXbox(), ShouldBeFalse)
+				}
+			})
+		})
+	})
+}

--- a/platforms/xbox.go
+++ b/platforms/xbox.go
@@ -1,0 +1,29 @@
+package platforms
+
+type Xbox struct {
+	p Parser
+}
+
+var (
+	xboxName       = "Xbox"
+	xboxMatchRegex = []string{`Xbox`}
+)
+
+func NewXbox(p Parser) *Xbox {
+	return &Xbox{
+		p: p,
+	}
+}
+
+func (k *Xbox) Name() string {
+	return xboxName
+}
+
+// Version returns empty string for Xbox
+func (k *Xbox) Version() string {
+	return ""
+}
+
+func (k *Xbox) Match() bool {
+	return k.p.Match(xboxMatchRegex)
+}

--- a/platforms/xbox_test.go
+++ b/platforms/xbox_test.go
@@ -1,0 +1,55 @@
+package platforms
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewXbox(t *testing.T) {
+	Convey("Subject: #NewXbox", t, func() {
+		Convey("It should return a new Xbox instance", func() {
+			So(NewXbox(NewUAParser("")), ShouldHaveSameTypeAs, &Xbox{})
+		})
+	})
+}
+
+func TestXboxName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return Xbox", func() {
+			So(NewXbox(NewUAParser("")).Name(), ShouldEqual, "Xbox")
+		})
+	})
+}
+
+func TestXboxVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It does not detect version", func() {
+				So(NewXbox(NewUAParser(testPlatforms["xbox"])).Version(), ShouldEqual, "")
+			})
+		})
+
+		Convey("When is not Xbox", func() {
+			Convey("It should return default version", func() {
+				So(NewXbox(NewUAParser(testPlatforms["firefox"])).Version(), ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func TestXboxMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches Xbox", func() {
+			Convey("It should return true", func() {
+				So(NewXbox(NewUAParser(testPlatforms["xbox"])).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match Xbox", func() {
+			Convey("It should return false", func() {
+				So(NewXbox(NewUAParser(testPlatforms["firefox"])).Match(), ShouldBeFalse)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Introduce a new Xbox platform matcher and integrate it into the platform detection logic. This includes adding corresponding tests and updating the platform registry to prioritize Xbox before Windows. Additionally, a new `IsXbox` method is implemented for streamlined platform checks.