### PR TITLE
Add WebOS platform support

### DIFF
--- a/assets/test/platforms.yml
+++ b/assets/test/platforms.yml
@@ -78,6 +78,8 @@ playstation-4: Mozilla/5.0 (PlayStation; PlayStation 4/12.00) AppleWebKit/605.1.
 playstation-5: Mozilla/5.0 (PlayStation; PlayStation 5/10.40; PlayStation 4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15
 playstation-smarttv: Mozilla/5.0 (PlayStation 5/SmartTV) AppleWebKit/605.1.15 (KHTML, like Gecko)
 playstation-vita: Mozilla/5.0 (PlayStation Vita 3.74) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2
+webos: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.34 Safari/537.36 DMOST/1.0.1 (; LGE; webOSTV; WEBOS4.1.0 04.10.40; W4_lm18a;)
+webos-hp: Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.5; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/234.83 Safari/534.6 TouchPad/1.0
 windows-10: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Atom/1.6.2 Chrome/45.0.2454.85 Electron/0.34.5 Safari/537.36
 windows-7: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0; Wildfire NoTrail; ProE-Datecode:3302014090)
 windows-8: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) your-app/0.1.0 Chrome/41.0.2272.76 Electron/0.24.0 Safari/537.36

--- a/platform.go
+++ b/platform.go
@@ -55,6 +55,7 @@ func (p *Platform) register() {
 		platforms.NewXbox(parser), // Should come before Windows
 		platforms.NewWindows(parser),
 		platforms.NewKindle(parser), // Should come before Android
+		platforms.NewWebOS(parser),  // Should come before Android
 		platforms.NewAndroid(parser),
 		platforms.NewLinux(parser),
 		platforms.NewFirefoxOS(parser),
@@ -358,6 +359,15 @@ func (p *Platform) IsWindowsTouchScreenDesktop() bool {
 // IsXbox returns true if the platform is Xbox.
 func (p *Platform) IsXbox() bool {
 	if _, ok := p.getMatcher().(*platforms.Xbox); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsXbox returns true if the platform is WebOS.
+func (p *Platform) IsWebOS() bool {
+	if _, ok := p.getMatcher().(*platforms.WebOS); ok {
 		return true
 	}
 

--- a/platform_test.go
+++ b/platform_test.go
@@ -655,3 +655,22 @@ func TestPlatformIsXbox(t *testing.T) {
 		})
 	})
 }
+
+func TestPlatformIsWebOS(t *testing.T) {
+	Convey("Given a user agent string", t, func() {
+		Convey("When the platform is WebOS", func() {
+			platforms := []string{"webos", "webos-hp"}
+			for _, platform := range platforms {
+				p, _ := NewPlatform(testPlatforms[platform])
+				So(p.IsWebOS(), ShouldBeTrue)
+			}
+		})
+
+		Convey("When the platform is not WebOS", func() {
+			Convey("It returns false", func() {
+				p, _ := NewPlatform(testPlatforms["android"])
+				So(p.IsWebOS(), ShouldBeFalse)
+			})
+		})
+	})
+}

--- a/platforms/webos.go
+++ b/platforms/webos.go
@@ -1,0 +1,30 @@
+package platforms
+
+type WebOS struct {
+	p Parser
+}
+
+var (
+	webOSName          = "WebOS"
+	webOSVersionRegexp = []string{`OS\/?([\d.]+)`}
+	webOSRegex         = []string{`(?i)WebOS|hpwOS`}
+)
+
+func NewWebOS(p Parser) *WebOS {
+	return &WebOS{
+		p: p,
+	}
+}
+
+func (k *WebOS) Name() string {
+	return webOSName
+}
+
+// Version returns version for WebOS
+func (k *WebOS) Version() string {
+	return k.p.Version(webOSVersionRegexp, 1, "")
+}
+
+func (k *WebOS) Match() bool {
+	return k.p.Match(webOSRegex)
+}

--- a/platforms/webos_test.go
+++ b/platforms/webos_test.go
@@ -1,0 +1,57 @@
+package platforms
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewWebOS(t *testing.T) {
+	Convey("Subject: #NewWebOS", t, func() {
+		Convey("It should return a new WebOS instance", func() {
+			So(NewWebOS(NewUAParser("")), ShouldHaveSameTypeAs, &WebOS{})
+		})
+	})
+}
+
+func TestWebOSName(t *testing.T) {
+	Convey("Subject: #Name", t, func() {
+		Convey("It should return WebOS", func() {
+			So(NewWebOS(NewUAParser("")).Name(), ShouldEqual, "WebOS")
+		})
+	})
+}
+
+func TestWebOSVersion(t *testing.T) {
+	Convey("Subject: #Version", t, func() {
+		Convey("When the version is matched", func() {
+			Convey("It should return the version", func() {
+				So(NewWebOS(NewUAParser(testPlatforms["webos"])).Version(), ShouldEqual, "4.1.0")
+				So(NewWebOS(NewUAParser(testPlatforms["webos-hp"])).Version(), ShouldEqual, "3.0.5")
+			})
+		})
+
+		Convey("When the version is not matched", func() {
+			Convey("It should return default version", func() {
+				So(NewWebOS(NewUAParser(testPlatforms["firefox"])).Version(), ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func TestWebOSMatch(t *testing.T) {
+	Convey("Subject: #Match", t, func() {
+		Convey("When user agent matches WebOS", func() {
+			Convey("It should return true", func() {
+				So(NewWebOS(NewUAParser(testPlatforms["webos"])).Match(), ShouldBeTrue)
+				So(NewWebOS(NewUAParser(testPlatforms["webos-hp"])).Match(), ShouldBeTrue)
+			})
+		})
+
+		Convey("When user agent does not match WebOS", func() {
+			Convey("It should return false", func() {
+				So(NewWebOS(NewUAParser(testPlatforms["firefox"])).Match(), ShouldBeFalse)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Implement WebOS platform detection and matching via user agents. Introduce related parsing logic, test cases, and validation within the platform framework.