### PR TITLE
Add support for detecting MacOS platform

### DIFF
--- a/platform.go
+++ b/platform.go
@@ -49,6 +49,7 @@ func (p *Platform) register() {
 		platforms.NewBlackBerry(parser),
 		platforms.NewKaiOS(parser),
 		platforms.NewIOS(parser),
+		platforms.NewMac(parser),
 		platforms.NewWatchOS(parser),
 		platforms.NewWindowsMobile(parser),
 		platforms.NewWindowsPhone(parser),
@@ -368,6 +369,15 @@ func (p *Platform) IsXbox() bool {
 // IsXbox returns true if the platform is WebOS.
 func (p *Platform) IsWebOS() bool {
 	if _, ok := p.getMatcher().(*platforms.WebOS); ok {
+		return true
+	}
+
+	return false
+}
+
+// IsMac returns true if the platform is MacOS
+func (p *Platform) IsMac() bool {
+	if _, ok := p.getMatcher().(*platforms.Mac); ok {
 		return true
 	}
 

--- a/platform_test.go
+++ b/platform_test.go
@@ -674,3 +674,22 @@ func TestPlatformIsWebOS(t *testing.T) {
 		})
 	})
 }
+
+func TestPlatformIsMacOS(t *testing.T) {
+	Convey("Given a user agent string", t, func() {
+		Convey("When the platform is MacOS", func() {
+			platforms := []string{"mac-os", "mac-os-1", "mac-os-x"}
+			for _, platform := range platforms {
+				p, _ := NewPlatform(testPlatforms[platform])
+				So(p.IsMac(), ShouldBeTrue)
+			}
+		})
+
+		Convey("When the platform is not MacOS", func() {
+			Convey("It returns false", func() {
+				p, _ := NewPlatform(testPlatforms["ios-7"])
+				So(p.IsMac(), ShouldBeFalse)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Introduced a new `IsMac` method to identify MacOS platforms. Updated the platform parser to handle MacOS and added corresponding test cases to validate the functionality.