### PR TITLE
Update baiduspider key in known_bots.yml

### DIFF
--- a/assets/internal/known_bots.yml
+++ b/assets/internal/known_bots.yml
@@ -21,7 +21,7 @@ archiveteam archivebot: ArchiveTeam ArchiveBot
 ask jeeves: Ask Jeeves
 asynchttpclient: Java http and WebSocket client library
 awe.sm: Awe.sm URL expander
-baidu: Baidu
+baiduspider: Baidu
 barkrowler: Barkrowler
 bdcbot: Big Data Corp
 becomebot: BecomeBot (become.com)


### PR DESCRIPTION
Renamed "Baidu" to "Baiduspider" to reflect its proper identification. This ensures consistency and accuracy in the bot naming conventions within the configuration.