### PR TITLE
Add support for SmartTV devices in TV detection logic

### DIFF
--- a/assets/test/devices.yml
+++ b/assets/test/devices.yml
@@ -70,6 +70,7 @@ switch-2: Opera/9.30 (Nintendo Switch; U; ; 2047-7; de)
 switch-3: Nintendo Wii Browser(Nintendo Switch Lite)
 tv-1: Mozilla/5.0 (Linux; Android 5.1.1; Nexus Player Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
 tv-2: Mozilla/5.0 (Linux; Android 5.0.2; ADT-1 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.94 Mobile Safari/537.36
+tv-3: Mozilla/5.0 (Linux; NetCast; U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.3945.79 Safari/537.36 SmartTV/10.0 Colt/2.0
 wii-1: MSIE 999; Nintendo WIi; Mozilla/5.0; (Win64)
 wii-2: Mozilla/5.0 (Nintendo Wii; U; en-US) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4200.1 Safari/537.36
 wii-3: Google Chrome/10 (Nintendo Wii)

--- a/device_test.go
+++ b/device_test.go
@@ -308,14 +308,16 @@ func TestDeviceIsTV(t *testing.T) {
 	Convey("Given a user agent string", t, func() {
 		Convey("When the device is a TV", func() {
 			Convey("It should return true", func() {
-				d, _ := NewDevice(testDevices["tv-1"])
-				So(d.IsTV(), ShouldBeTrue)
+				for _, ua := range []string{testDevices["tv-1"], testDevices["tv-2"], testDevices["tv-3"]} {
+					d, _ := NewDevice(ua)
+					So(d.IsTV(), ShouldBeTrue)
+				}
 			})
 		})
 
 		Convey("When the device is not a TV", func() {
 			Convey("It should return false", func() {
-				d, _ := NewDevice(testDevices["iphone-7"])
+				d, _ := NewDevice(testDevices["android-12"])
 				So(d.IsTV(), ShouldBeFalse)
 			})
 		})

--- a/devices/tv.go
+++ b/devices/tv.go
@@ -6,7 +6,7 @@ type TV struct {
 
 var (
 	tvName       = "TV"
-	tvMatchRegex = []string{`(?i)(\btv|Android.*?ADT-1|Nexus Player)`}
+	tvMatchRegex = []string{`(?i)(\btv|Android.*?ADT-1|Nexus Player|SmartTV)`}
 )
 
 func NewTV(p Parser) *TV {


### PR DESCRIPTION
Updated the TV detection regex to recognize SmartTV user agents. Added a new test case for SmartTV and expanded existing tests to cover additional TV user agents. This ensures improved accuracy in device classification.